### PR TITLE
feat(magic): detect application/json from leading bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Detect `application/json` from leading bytes via a bounded JSON-prefix
+  validator. Top-level objects (`{...}`) and arrays (`[...]`) are recognized
+  after optional UTF-8 BOM and whitespace, including truncated inputs.
+  Bare top-level scalars (numbers, strings, `true`/`false`/`null`) are
+  intentionally not sniffed to avoid false positives on plain text. (#19)
+
 ## [0.1.0] - 2026-04-26
 
 - Added the initial cross-target Gleam project scaffold (`just`, `mise`, CI, release workflow).

--- a/src/mimetype/internal/magic.gleam
+++ b/src/mimetype/internal/magic.gleam
@@ -108,6 +108,7 @@ const signatures = [
   Bytes("video/mp4", [#(4, <<"ftyp":utf8>>), #(8, <<"mp41":utf8>>)]),
   Bytes("video/mp4", [#(4, <<"ftyp":utf8>>), #(8, <<"mp42":utf8>>)]),
   Bytes("video/mp4", [#(4, <<"ftyp":utf8>>), #(8, <<"avc1":utf8>>)]),
+  Check("application/json", looks_like_json),
 ]
 
 /// Try to recognize a MIME type from a leading byte signature.
@@ -178,5 +179,208 @@ fn has_bytes_at(bytes: BitArray, offset: Int, prefix: BitArray) -> Bool {
     False ->
       bit_array.slice(bytes, offset, prefix_size) |> result.unwrap(<<>>)
       == prefix
+  }
+}
+
+// JSON sniffing: recognize `application/json` from leading bytes.
+//
+// Detection scope (top level): only `{...}` and `[...]` are sniffed. Bare
+// scalars (numbers, strings, `true`/`false`/`null`) at the top level are
+// rejected because they false-positive on plain text. Inside containers,
+// numbers and the literals are accepted as element values.
+//
+// Truncated input (e.g. `{"a": 1`) is accepted as JSON: structural validity
+// of the prefix is sufficient for sniffing. Junk after `{` (e.g.
+// `{ this is not json }`) is rejected because the object body requires `"`
+// or `}` after whitespace.
+//
+// Walking is bounded by `json_sniff_budget` so that arbitrarily large inputs
+// short-circuit once enough valid prefix has been observed.
+
+const json_sniff_budget = 4096
+
+type JsonResult {
+  Valid(BitArray, Int)
+  Truncated
+  Invalid
+}
+
+fn looks_like_json(bytes: BitArray) -> Bool {
+  let stripped = json_strip_bom(bytes)
+  let #(after_ws, budget) = json_skip_ws(stripped, json_sniff_budget)
+  case after_ws {
+    <<0x7B, rest:bits>> ->
+      json_finalize(json_validate_object(rest, budget - 1, True))
+    <<0x5B, rest:bits>> ->
+      json_finalize(json_validate_array(rest, budget - 1, True))
+    _ -> False
+  }
+}
+
+fn json_finalize(result: JsonResult) -> Bool {
+  case result {
+    Valid(_, _) -> True
+    Truncated -> True
+    Invalid -> False
+  }
+}
+
+fn json_strip_bom(bytes: BitArray) -> BitArray {
+  case bytes {
+    <<0xEF, 0xBB, 0xBF, rest:bits>> -> rest
+    _ -> bytes
+  }
+}
+
+fn json_skip_ws(bytes: BitArray, budget: Int) -> #(BitArray, Int) {
+  use <- bool.guard(when: budget <= 0, return: #(bytes, budget))
+  case bytes {
+    <<0x20, rest:bits>> -> json_skip_ws(rest, budget - 1)
+    <<0x09, rest:bits>> -> json_skip_ws(rest, budget - 1)
+    <<0x0A, rest:bits>> -> json_skip_ws(rest, budget - 1)
+    <<0x0D, rest:bits>> -> json_skip_ws(rest, budget - 1)
+    _ -> #(bytes, budget)
+  }
+}
+
+fn json_then(
+  result: JsonResult,
+  next: fn(BitArray, Int) -> JsonResult,
+) -> JsonResult {
+  case result {
+    Valid(rest, budget) -> next(rest, budget)
+    Truncated -> Truncated
+    Invalid -> Invalid
+  }
+}
+
+fn json_validate_value(bytes: BitArray, budget: Int) -> JsonResult {
+  use <- bool.lazy_guard(when: budget <= 0, return: fn() { Truncated })
+  let #(b, budget) = json_skip_ws(bytes, budget)
+  case b {
+    <<>> -> Truncated
+    <<0x7B, rest:bits>> -> json_validate_object(rest, budget - 1, True)
+    <<0x5B, rest:bits>> -> json_validate_array(rest, budget - 1, True)
+    <<0x22, rest:bits>> -> json_skip_string(rest, budget - 1)
+    <<0x74, rest:bits>> -> json_match_literal(rest, <<"rue":utf8>>, budget - 1)
+    <<0x66, rest:bits>> -> json_match_literal(rest, <<"alse":utf8>>, budget - 1)
+    <<0x6E, rest:bits>> -> json_match_literal(rest, <<"ull":utf8>>, budget - 1)
+    <<0x2D, _:bits>> -> json_skip_number(b, budget)
+    <<x, _:bits>> if x >= 0x30 && x <= 0x39 -> json_skip_number(b, budget)
+    _ -> Invalid
+  }
+}
+
+fn json_validate_object(
+  bytes: BitArray,
+  budget: Int,
+  expecting_first: Bool,
+) -> JsonResult {
+  let #(b, budget) = json_skip_ws(bytes, budget)
+  case b {
+    <<>> -> Truncated
+    <<0x7D, rest:bits>> -> {
+      use <- bool.guard(when: !expecting_first, return: Invalid)
+      Valid(rest, budget - 1)
+    }
+    <<0x22, rest:bits>> -> json_validate_object_member(rest, budget - 1)
+    _ -> Invalid
+  }
+}
+
+fn json_validate_object_member(bytes: BitArray, budget: Int) -> JsonResult {
+  use after_key, budget <- json_then(json_skip_string(bytes, budget))
+  let #(b, budget) = json_skip_ws(after_key, budget)
+  case b {
+    <<>> -> Truncated
+    <<0x3A, after_colon:bits>> -> {
+      use after_value, budget <- json_then(json_validate_value(
+        after_colon,
+        budget - 1,
+      ))
+      let #(b, budget) = json_skip_ws(after_value, budget)
+      case b {
+        <<>> -> Truncated
+        <<0x2C, rest:bits>> -> json_validate_object(rest, budget - 1, False)
+        <<0x7D, rest:bits>> -> Valid(rest, budget - 1)
+        _ -> Invalid
+      }
+    }
+    _ -> Invalid
+  }
+}
+
+fn json_validate_array(
+  bytes: BitArray,
+  budget: Int,
+  expecting_first: Bool,
+) -> JsonResult {
+  let #(b, budget) = json_skip_ws(bytes, budget)
+  case b {
+    <<>> -> Truncated
+    <<0x5D, rest:bits>> -> {
+      use <- bool.guard(when: !expecting_first, return: Invalid)
+      Valid(rest, budget - 1)
+    }
+    _ -> {
+      use after_value, budget <- json_then(json_validate_value(b, budget))
+      let #(b, budget) = json_skip_ws(after_value, budget)
+      case b {
+        <<>> -> Truncated
+        <<0x2C, rest:bits>> -> json_validate_array(rest, budget - 1, False)
+        <<0x5D, rest:bits>> -> Valid(rest, budget - 1)
+        _ -> Invalid
+      }
+    }
+  }
+}
+
+fn json_skip_string(bytes: BitArray, budget: Int) -> JsonResult {
+  use <- bool.lazy_guard(when: budget <= 0, return: fn() { Truncated })
+  case bytes {
+    <<>> -> Truncated
+    <<0x22, rest:bits>> -> Valid(rest, budget - 1)
+    <<0x5C, _esc, rest:bits>> -> json_skip_string(rest, budget - 2)
+    <<0x5C>> -> Truncated
+    <<_b, rest:bits>> -> json_skip_string(rest, budget - 1)
+    _ -> Invalid
+  }
+}
+
+fn json_skip_number(bytes: BitArray, budget: Int) -> JsonResult {
+  use <- bool.lazy_guard(when: budget <= 0, return: fn() { Truncated })
+  case bytes {
+    <<>> -> Truncated
+    <<0x2D, rest:bits>> -> json_skip_number_digits(rest, budget - 1)
+    <<b, _:bits>> if b >= 0x30 && b <= 0x39 ->
+      json_skip_number_digits(bytes, budget)
+    _ -> Invalid
+  }
+}
+
+fn json_skip_number_digits(bytes: BitArray, budget: Int) -> JsonResult {
+  use <- bool.lazy_guard(when: budget <= 0, return: fn() { Truncated })
+  case bytes {
+    <<>> -> Truncated
+    <<b, rest:bits>> if b >= 0x30 && b <= 0x39 ->
+      json_skip_number_digits(rest, budget - 1)
+    <<0x2E, rest:bits>> -> json_skip_number_digits(rest, budget - 1)
+    <<0x65, rest:bits>> -> json_skip_number_digits(rest, budget - 1)
+    <<0x45, rest:bits>> -> json_skip_number_digits(rest, budget - 1)
+    <<0x2B, rest:bits>> -> json_skip_number_digits(rest, budget - 1)
+    <<0x2D, rest:bits>> -> json_skip_number_digits(rest, budget - 1)
+    _ -> Valid(bytes, budget)
+  }
+}
+
+fn json_match_literal(bytes: BitArray, lit: BitArray, budget: Int) -> JsonResult {
+  case bytes, lit {
+    _, <<>> -> Valid(bytes, budget)
+    <<>>, _ -> Truncated
+    <<b, b_rest:bits>>, <<l, l_rest:bits>> -> {
+      use <- bool.guard(when: b != l, return: Invalid)
+      json_match_literal(b_rest, l_rest, budget - 1)
+    }
+    _, _ -> Invalid
   }
 }

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -428,3 +428,124 @@ pub fn detect_with_filename_prefers_magic_over_extension_test() {
   )
   |> should.equal("image/png")
 }
+
+pub fn detect_json_empty_object_test() {
+  should_detect(<<"{}":utf8>>, "application/json")
+}
+
+pub fn detect_json_empty_array_test() {
+  should_detect(<<"[]":utf8>>, "application/json")
+}
+
+pub fn detect_json_object_with_nested_array_test() {
+  should_detect(<<"{\"a\": 1, \"b\": [true, null]}":utf8>>, "application/json")
+}
+
+pub fn detect_json_array_of_numbers_test() {
+  should_detect(<<"[1, 2, 3]":utf8>>, "application/json")
+}
+
+pub fn detect_json_array_of_strings_test() {
+  should_detect(<<"[\"a\", \"b\", \"c\"]":utf8>>, "application/json")
+}
+
+pub fn detect_json_with_leading_whitespace_test() {
+  should_detect(<<"   \n  {\"a\":1}":utf8>>, "application/json")
+}
+
+pub fn detect_json_with_utf8_bom_test() {
+  should_detect(<<0xEF, 0xBB, 0xBF, "{\"a\":1}":utf8>>, "application/json")
+}
+
+pub fn detect_json_truncated_object_test() {
+  should_detect(<<"{\"a\": 1":utf8>>, "application/json")
+}
+
+pub fn detect_json_truncated_array_test() {
+  should_detect(<<"[1, 2,":utf8>>, "application/json")
+}
+
+pub fn detect_json_string_with_escaped_quote_test() {
+  should_detect(<<"{\"k\":\"a\\\"b\"}":utf8>>, "application/json")
+}
+
+pub fn detect_json_string_with_escaped_backslash_test() {
+  should_detect(<<"{\"k\":\"a\\\\b\"}":utf8>>, "application/json")
+}
+
+pub fn detect_json_negative_number_test() {
+  should_detect(<<"[-1, -2.5, -1e10]":utf8>>, "application/json")
+}
+
+pub fn detect_json_nested_object_test() {
+  should_detect(<<"{\"a\":{\"b\":{\"c\":1}}}":utf8>>, "application/json")
+}
+
+pub fn detect_json_rejects_unquoted_words_test() {
+  should_fall_back(<<"{ this is not json }":utf8>>)
+}
+
+pub fn detect_json_rejects_plain_text_test() {
+  should_fall_back(<<"Hello world":utf8>>)
+}
+
+pub fn detect_json_rejects_html_test() {
+  should_fall_back(<<"<html>":utf8>>)
+}
+
+pub fn detect_json_rejects_bare_number_test() {
+  should_fall_back(<<"42":utf8>>)
+}
+
+pub fn detect_json_rejects_bare_string_test() {
+  should_fall_back(<<"\"foo\"":utf8>>)
+}
+
+pub fn detect_json_rejects_bare_true_test() {
+  should_fall_back(<<"true":utf8>>)
+}
+
+pub fn detect_json_rejects_bom_only_test() {
+  should_fall_back(<<0xEF, 0xBB, 0xBF>>)
+}
+
+pub fn detect_json_rejects_open_brace_with_garbage_test() {
+  should_fall_back(<<"{abc":utf8>>)
+}
+
+pub fn detect_json_rejects_object_with_unquoted_key_test() {
+  should_fall_back(<<"{key: 1}":utf8>>)
+}
+
+pub fn detect_json_rejects_object_missing_colon_test() {
+  should_fall_back(<<"{\"key\" 1}":utf8>>)
+}
+
+pub fn detect_json_rejects_trailing_comma_in_object_test() {
+  should_fall_back(<<"{\"a\":1,}":utf8>>)
+}
+
+pub fn detect_json_rejects_trailing_comma_in_array_test() {
+  should_fall_back(<<"[1,2,]":utf8>>)
+}
+
+pub fn detect_json_strict_returns_ok_test() {
+  mimetype.detect_strict(<<"{\"x\":1}":utf8>>)
+  |> should.equal(Ok("application/json"))
+}
+
+pub fn detect_json_array_of_objects_test() {
+  should_detect(<<"[{\"a\":1},{\"b\":2}]":utf8>>, "application/json")
+}
+
+pub fn detect_json_object_with_multibyte_utf8_value_test() {
+  should_detect(<<"{\"name\":\"日本語\"}":utf8>>, "application/json")
+}
+
+pub fn detect_json_rejects_whitespace_only_test() {
+  should_fall_back(<<" \n\t\r ":utf8>>)
+}
+
+pub fn detect_json_truncated_after_whitespace_test() {
+  should_detect(<<"{\"a\":   ":utf8>>, "application/json")
+}


### PR DESCRIPTION
## Summary

Recognize `application/json` from leading bytes of a `BitArray`. Top-level
JSON objects (`{...}`) and arrays (`[...]`) are sniffed after stripping an
optional UTF-8 BOM and ASCII whitespace. Inputs that look like JSON but are
truncated mid-document (e.g. `{"a": 1`) are accepted on the rationale that
sniffing operates on prefixes; obvious garbage (e.g. `{ this is not json }`)
is rejected because the object body validator requires `"` or `}` after
whitespace.

## Changes

- `src/mimetype/internal/magic.gleam`
  - Added `Check("application/json", looks_like_json)` as the final entry in
    the `signatures` list. Placement at the end keeps binary-input detection
    (PNG/JPEG/ZIP/etc.) on the cheap `Bytes` fast path and only invokes the
    JSON validator when no binary signature matches.
  - Added a private recursive-descent JSON-prefix validator: `JsonResult`
    ADT (`Valid` / `Truncated` / `Invalid`), `looks_like_json`,
    `json_strip_bom`, `json_skip_ws`, `json_validate_value`,
    `json_validate_object` (+ `json_validate_object_member`),
    `json_validate_array`, `json_skip_string`, `json_skip_number` (+
    `json_skip_number_digits`), `json_match_literal`, and a `json_then`
    monadic helper to keep call sites flat under glinter's
    `prefer_guard_clause`.
  - A `json_sniff_budget = 4096` constant caps the byte walk so multi-MB
    inputs short-circuit on `Truncated`.
- `test/mimetype_test.gleam`
  - Added 29 tests under `detect_json_*` covering empty / nested / truncated
    objects and arrays, leading whitespace, UTF-8 BOM, escaped quotes /
    backslashes, negative numbers, multi-byte UTF-8 string values, and
    rejection cases (unquoted keys, missing colons, trailing commas, bare
    scalars / literals, BOM-only, plain text, HTML).
- `CHANGELOG.md`
  - Recorded the addition under `## Unreleased`, with a note on the
    intentional non-detection of bare top-level scalars.

## Design Decisions

- **Top-level only `{` / `[`.** Bare top-level scalars (`42`, `"foo"`,
  `true`) are deliberately *not* sniffed. Each is a valid JSON value per
  RFC 8259 but matches benign plain text far too often (the literal "true"
  appears in English prose; numbers in CSV-ish blobs; bare strings as
  arbitrary text). Inside containers, numbers and `true`/`false`/`null` are
  validated as element values, so realistic JSON like `{"a": true}` and
  `[1,2,3]` is detected.
- **Truncated input is accepted.** Sniffing typically sees only the first
  few KB of a stream. A structurally valid JSON prefix that runs out of
  input (`{"items": [`) is treated as `Truncated`, which `looks_like_json`
  maps to `True`. This mirrors how the Go `gabriel-vasile/mimetype` library
  handles partial reads.
- **Bounded by `json_sniff_budget = 4096`.** Once the validator has stepped
  through 4 KB of structurally valid prefix, budget exhaustion converts to
  `Truncated`, returning `True`. This avoids walking arbitrarily large
  inputs and gives a stable upper bound on detection cost.
- **Object body is strict.** After `{` and whitespace the validator
  requires `"` (key) or `}` (close). This is what catches `{ this is not
  json }`: `t` does not match `"` so we return `Invalid`. Trailing commas
  (`{"a":1,}`) are rejected for the same reason.
- **String escapes are partially validated.** `\"` and `\\` are honored so
  closing-quote detection is correct. Unicode escapes (`\uXXXX`) and other
  escape forms are treated as opaque bytes — sufficient for sniffing,
  which only needs to find the structural envelope.
- **Glinter-friendly shape.** Rather than nest `case` arms, the
  implementation threads `JsonResult` through a `json_then` bind helper and
  uses `bool.guard` / `bool.lazy_guard` for early returns, keeping every
  function body shallow. `gleam format`, `glinter` strict mode, builds for
  both Erlang and JavaScript targets, and tests on both targets all pass
  via `just all`.

## Limitations

- Detection runs on every invocation that no other binary signature matched
  — it costs at most ~4 KB of byte stepping but is not free for non-JSON
  text inputs. A future signature-table indexing pass could short-circuit
  this when the first non-whitespace byte is not `{` or `[`.
- The validator is intentionally permissive about JSON-string contents (no
  UTF-8 well-formedness check, no `\uXXXX` validation). This produces no
  false negatives for real JSON and the false-positive rate on weird-but-
  structurally-valid containers is acceptable for sniffing.
- Numbers and bare top-level literals (`true` / `false` / `null` /
  `"string"` / `42`) at the document root are out of scope per the issue.
  They could be added later by extending `looks_like_json`'s top-level
  switch with the existing `json_match_literal` / `json_skip_number`
  helpers — but a stricter "nothing follows except whitespace/EOF" rule
  would be needed to keep false-positive rates down on plain text.

Closes #19
