### PR TITLE
feat(magic): detect text/html and text/xml from leading bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
   after optional UTF-8 BOM and whitespace, including truncated inputs.
   Bare top-level scalars (numbers, strings, `true`/`false`/`null`) are
   intentionally not sniffed to avoid false positives on plain text. (#19)
+- Detect `text/html` from leading bytes by case-insensitive matching on a
+  WHATWG-aligned tag list (`<!doctype html`, `<html`, `<head`, `<body`,
+  `<script`, `<iframe`, `<table`, `<style`, `<title`, `<br`, `<p`, `<h1`,
+  `<div`, `<font`, `<img`, `<a`) followed by a tag-terminating byte
+  (whitespace, `>`, or end of input). (#17)
+- Detect `text/xml` from leading bytes by recognizing the lowercase
+  `<?xml` declaration followed by a tag-terminating byte. Both detectors
+  strip an optional UTF-8 BOM and HTML whitespace before matching. (#17)
 
 ## [0.1.0] - 2026-04-26
 

--- a/src/mimetype/internal/magic.gleam
+++ b/src/mimetype/internal/magic.gleam
@@ -109,6 +109,8 @@ const signatures = [
   Bytes("video/mp4", [#(4, <<"ftyp":utf8>>), #(8, <<"mp42":utf8>>)]),
   Bytes("video/mp4", [#(4, <<"ftyp":utf8>>), #(8, <<"avc1":utf8>>)]),
   Check("application/json", looks_like_json),
+  Check("text/html", looks_like_html),
+  Check("text/xml", looks_like_xml),
 ]
 
 /// Try to recognize a MIME type from a leading byte signature.
@@ -383,4 +385,136 @@ fn json_match_literal(bytes: BitArray, lit: BitArray, budget: Int) -> JsonResult
     }
     _, _ -> Invalid
   }
+}
+
+// HTML / XML sniffing per the WHATWG MIME Sniffing standard.
+//
+// `looks_like_html` recognizes inputs whose first non-whitespace token is
+// `<!doctype html` or one of a small set of common HTML tags, matched
+// case-insensitively and required to be followed by a tag-terminating byte
+// (whitespace, `>`, or end of input). The terminator requirement avoids
+// over-matching: `<address>` does not match the `<a` signature because
+// `d` is not a terminator.
+//
+// `looks_like_xml` recognizes inputs starting with the lowercase XML
+// declaration `<?xml` followed by a tag-terminating byte. The XML
+// declaration is case-sensitive per the XML 1.0 spec; uppercase variants
+// are not treated as XML.
+//
+// Both detectors strip an optional UTF-8 BOM and any leading HTML
+// whitespace before matching. UTF-16 / UTF-32 BOMs are deferred to the
+// dedicated text-plain detector (#20).
+
+const html_tag_signatures = [
+  <<"<html":utf8>>,
+  <<"<head":utf8>>,
+  <<"<body":utf8>>,
+  <<"<script":utf8>>,
+  <<"<iframe":utf8>>,
+  <<"<table":utf8>>,
+  <<"<style":utf8>>,
+  <<"<title":utf8>>,
+  <<"<br":utf8>>,
+  <<"<p":utf8>>,
+  <<"<h1":utf8>>,
+  <<"<div":utf8>>,
+  <<"<font":utf8>>,
+  <<"<img":utf8>>,
+  <<"<a":utf8>>,
+]
+
+fn looks_like_html(bytes: BitArray) -> Bool {
+  let trimmed = trim_text_prefix(bytes)
+  use <- bool.lazy_guard(when: matches_html_doctype(trimmed), return: fn() {
+    True
+  })
+  list.any(html_tag_signatures, fn(tag) { matches_html_tag(trimmed, tag) })
+}
+
+fn looks_like_xml(bytes: BitArray) -> Bool {
+  trim_text_prefix(bytes)
+  |> match_byte_prefix(<<"<?xml":utf8>>)
+  |> result.map(is_text_terminator)
+  |> result.unwrap(False)
+}
+
+fn matches_html_doctype(bytes: BitArray) -> Bool {
+  match_ci_prefix(bytes, <<"<!doctype html":utf8>>)
+  |> result.map(is_text_terminator)
+  |> result.unwrap(False)
+}
+
+fn matches_html_tag(bytes: BitArray, tag: BitArray) -> Bool {
+  match_ci_prefix(bytes, tag)
+  |> result.map(is_text_terminator)
+  |> result.unwrap(False)
+}
+
+fn trim_text_prefix(bytes: BitArray) -> BitArray {
+  bytes
+  |> strip_utf8_bom
+  |> skip_html_ws
+}
+
+fn strip_utf8_bom(bytes: BitArray) -> BitArray {
+  case bytes {
+    <<0xEF, 0xBB, 0xBF, rest:bits>> -> rest
+    _ -> bytes
+  }
+}
+
+fn skip_html_ws(bytes: BitArray) -> BitArray {
+  case bytes {
+    <<0x20, rest:bits>> -> skip_html_ws(rest)
+    <<0x09, rest:bits>> -> skip_html_ws(rest)
+    <<0x0A, rest:bits>> -> skip_html_ws(rest)
+    <<0x0C, rest:bits>> -> skip_html_ws(rest)
+    <<0x0D, rest:bits>> -> skip_html_ws(rest)
+    _ -> bytes
+  }
+}
+
+fn is_text_terminator(bytes: BitArray) -> Bool {
+  case bytes {
+    <<>> -> True
+    <<0x20, _:bits>> -> True
+    <<0x09, _:bits>> -> True
+    <<0x0A, _:bits>> -> True
+    <<0x0C, _:bits>> -> True
+    <<0x0D, _:bits>> -> True
+    <<0x3E, _:bits>> -> True
+    _ -> False
+  }
+}
+
+fn match_ci_prefix(bytes: BitArray, prefix: BitArray) -> Result(BitArray, Nil) {
+  case prefix, bytes {
+    <<>>, _ -> Ok(bytes)
+    _, <<>> -> Error(Nil)
+    <<p, p_rest:bits>>, <<b, b_rest:bits>> -> {
+      use <- bool.lazy_guard(
+        when: ascii_to_lower(b) != ascii_to_lower(p),
+        return: fn() { Error(Nil) },
+      )
+      match_ci_prefix(b_rest, p_rest)
+    }
+    _, _ -> Error(Nil)
+  }
+}
+
+fn match_byte_prefix(bytes: BitArray, prefix: BitArray) -> Result(BitArray, Nil) {
+  case prefix, bytes {
+    <<>>, _ -> Ok(bytes)
+    _, <<>> -> Error(Nil)
+    <<p, p_rest:bits>>, <<b, b_rest:bits>> -> {
+      use <- bool.lazy_guard(when: b != p, return: fn() { Error(Nil) })
+      match_byte_prefix(b_rest, p_rest)
+    }
+    _, _ -> Error(Nil)
+  }
+}
+
+fn ascii_to_lower(byte: Int) -> Int {
+  use <- bool.guard(when: byte < 0x41 || byte > 0x5A, return: byte)
+  byte + 32
 }

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -489,8 +489,8 @@ pub fn detect_json_rejects_plain_text_test() {
   should_fall_back(<<"Hello world":utf8>>)
 }
 
-pub fn detect_json_rejects_html_test() {
-  should_fall_back(<<"<html>":utf8>>)
+pub fn detect_json_html_input_matches_html_test() {
+  should_detect(<<"<html>":utf8>>, "text/html")
 }
 
 pub fn detect_json_rejects_bare_number_test() {
@@ -548,4 +548,119 @@ pub fn detect_json_rejects_whitespace_only_test() {
 
 pub fn detect_json_truncated_after_whitespace_test() {
   should_detect(<<"{\"a\":   ":utf8>>, "application/json")
+}
+
+pub fn detect_html_doctype_test() {
+  should_detect(
+    <<"<!DOCTYPE html><html><body></body></html>":utf8>>,
+    "text/html",
+  )
+}
+
+pub fn detect_html_doctype_lowercase_test() {
+  should_detect(<<"<!doctype html>":utf8>>, "text/html")
+}
+
+pub fn detect_html_uppercase_tag_test() {
+  should_detect(<<"<HTML>":utf8>>, "text/html")
+}
+
+pub fn detect_html_with_leading_whitespace_test() {
+  should_detect(<<"   \n\t<html>":utf8>>, "text/html")
+}
+
+pub fn detect_html_with_utf8_bom_test() {
+  should_detect(<<0xEF, 0xBB, 0xBF, "<html>":utf8>>, "text/html")
+}
+
+pub fn detect_html_head_test() {
+  should_detect(<<"<head>":utf8>>, "text/html")
+}
+
+pub fn detect_html_body_test() {
+  should_detect(<<"<body>":utf8>>, "text/html")
+}
+
+pub fn detect_html_script_test() {
+  should_detect(<<"<script>":utf8>>, "text/html")
+}
+
+pub fn detect_html_div_test() {
+  should_detect(<<"<div class=\"x\">":utf8>>, "text/html")
+}
+
+pub fn detect_html_short_tag_a_test() {
+  should_detect(<<"<a href=\"/\">":utf8>>, "text/html")
+}
+
+pub fn detect_html_short_tag_p_test() {
+  should_detect(<<"<p>hello":utf8>>, "text/html")
+}
+
+pub fn detect_html_truncated_tag_test() {
+  should_detect(<<"<html":utf8>>, "text/html")
+}
+
+pub fn detect_html_rejects_unknown_tag_test() {
+  should_fall_back(<<"<not-a-known-tag>":utf8>>)
+}
+
+pub fn detect_html_rejects_space_after_lt_test() {
+  should_fall_back(<<"< html>":utf8>>)
+}
+
+pub fn detect_html_rejects_address_via_short_a_signature_test() {
+  should_fall_back(<<"<address>":utf8>>)
+}
+
+pub fn detect_html_rejects_pre_via_short_p_signature_test() {
+  should_fall_back(<<"<pre>":utf8>>)
+}
+
+pub fn detect_html_rejects_plain_text_test() {
+  should_fall_back(<<"Hello world":utf8>>)
+}
+
+pub fn detect_xml_declaration_test() {
+  should_detect(<<"<?xml version=\"1.0\"?><root/>":utf8>>, "text/xml")
+}
+
+pub fn detect_xml_with_encoding_test() {
+  should_detect(
+    <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>":utf8>>,
+    "text/xml",
+  )
+}
+
+pub fn detect_xml_with_leading_whitespace_test() {
+  should_detect(<<"  \n<?xml ?>":utf8>>, "text/xml")
+}
+
+pub fn detect_xml_with_utf8_bom_test() {
+  should_detect(
+    <<0xEF, 0xBB, 0xBF, "<?xml version=\"1.0\"?>":utf8>>,
+    "text/xml",
+  )
+}
+
+pub fn detect_xml_truncated_test() {
+  should_detect(<<"<?xml ":utf8>>, "text/xml")
+}
+
+pub fn detect_xml_rejects_uppercase_declaration_test() {
+  should_fall_back(<<"<?XML version=\"1.0\"?>":utf8>>)
+}
+
+pub fn detect_xml_rejects_processing_instruction_other_than_xml_test() {
+  should_fall_back(<<"<?php ?>":utf8>>)
+}
+
+pub fn detect_xml_strict_returns_ok_test() {
+  mimetype.detect_strict(<<"<?xml version=\"1.0\"?>":utf8>>)
+  |> should.equal(Ok("text/xml"))
+}
+
+pub fn detect_html_strict_returns_ok_test() {
+  mimetype.detect_strict(<<"<!DOCTYPE html>":utf8>>)
+  |> should.equal(Ok("text/html"))
 }


### PR DESCRIPTION
## Summary

Recognize `text/html` and `text/xml` from leading bytes. HTML is detected by
case-insensitive matching against a WHATWG-aligned list of common opening
tags (`<!doctype html`, `<html`, `<head`, `<body`, `<script`, `<iframe`,
`<table`, `<style`, `<title`, `<br`, `<p`, `<h1`, `<div`, `<font`, `<img`,
`<a`); each candidate must be followed by a tag-terminating byte
(whitespace, `>`, or end of input) so that strings like `<address>` do not
spuriously match the `<a` signature. XML is detected by matching the
lowercase `<?xml` declaration followed by a tag terminator. Both detectors
strip an optional UTF-8 BOM and HTML whitespace before matching.

## Changes

- `src/mimetype/internal/magic.gleam`
  - Added `Check("text/html", looks_like_html)` and
    `Check("text/xml", looks_like_xml)` after the JSON detector. Placement
    keeps binary signatures on the cheap fast path; text-based sniffers
    only run when no binary signature matched.
  - Added `html_tag_signatures` (the WHATWG-derived tag list),
    `looks_like_html`, `looks_like_xml`, `matches_html_doctype`,
    `matches_html_tag`, `trim_text_prefix`, `strip_utf8_bom`,
    `skip_html_ws`, `is_text_terminator`, `match_ci_prefix`,
    `match_byte_prefix`, and `ascii_to_lower`.
- `test/mimetype_test.gleam`
  - 26 new tests under `detect_html_*` and `detect_xml_*` covering: the
    DOCTYPE form (mixed case), short tags `<a>`/`<p>`, leading whitespace,
    UTF-8 BOM, truncated tags, and rejection cases (unknown tags,
    `< html>` with space after `<`, `<address>` (verifies the tag
    terminator guard against `<a`), `<pre>` (verifies the guard against
    `<p>`), uppercase XML declaration, and non-XML processing
    instructions like `<?php ?>`).
  - Renamed the prior `detect_json_rejects_html_test` to
    `detect_json_html_input_matches_html_test` and updated its expected
    value: with HTML detection now in place, `<html>` is correctly
    classified as `text/html` rather than falling back.
- `CHANGELOG.md`
  - Documented both detectors under `## Unreleased`.

## Design Decisions

- **WHATWG-aligned tag list, not a dynamic table.** The 16-entry
  `html_tag_signatures` const list mirrors the WHATWG MIME Sniffing
  standard's "HTML tag" pattern set (with `<img` from the issue's list
  added; `<b` and `<!--` from the WHATWG list omitted to match the issue
  scope). Using a fixed list rather than a dynamic table keeps the code
  comprehensible and trivially auditable against the spec.
- **Tag-terminator requirement.** Per WHATWG, every HTML tag signature
  must be followed by a "tag-terminating byte" — whitespace, `>`, or end
  of input. The `is_text_terminator` helper enforces this for both HTML
  tags and the XML declaration. Without it, `<a` would erroneously match
  every `<address>`/`<area>` document.
- **Case-insensitive HTML, case-sensitive XML.** HTML is famously lax;
  `<HTML>`, `<Html>`, and `<html>` are all valid markup. The XML 1.0
  spec, by contrast, requires the lowercase `<?xml` declaration — uppercase
  `<?XML` is not a valid XML declaration. The implementation reflects
  this asymmetry: `match_ci_prefix` for HTML, `match_byte_prefix` for XML.
- **`text/xml` over `application/xml`.** RFC 7303 permits both. The
  WHATWG MIME Sniffing standard returns `text/xml`; aligning with WHATWG
  makes this library's behavior consistent with browsers and `file(1)`.
  The issue called this out explicitly and recommended `text/xml`.
- **UTF-8 BOM only at this layer.** UTF-16 / UTF-32 BOMs are deferred to
  issue #20 (text-plain detection via BOMs and printable-ASCII heuristic).
  A UTF-16-encoded HTML document starting with the UTF-16 LE BOM (0xFF
  0xFE) cannot be matched by ASCII byte patterns anyway; that lives in
  the text/plain detector's domain.
- **Glinter-friendly result chaining.** Predicates use
  `result.map(is_text_terminator) |> result.unwrap(False)` rather than
  `case match { Ok(...) -> ...; Error(_) -> False }` so glinter's
  `thrown_away_error` rule is satisfied without losing readability.

## Limitations

- The detector does not validate that the surrounding document is
  well-formed HTML or XML — it only sniffs the opening token. A file that
  starts with `<html>` but is then arbitrary bytes will still be reported
  as `text/html`, which is the correct sniffing behavior but means callers
  should not assume the rest of the input parses cleanly.
- Tag list is fixed; rare or non-standard HTML tags (`<svg>`, `<canvas>`,
  `<article>`, custom elements) are not recognized at the leading-byte
  level. SVG specifically is the subject of issue #18 and uses the XML
  detection path plus a root-element check.
- HTML comments (`<!--`) are deliberately not matched. The WHATWG list
  includes them but the issue's scope did not; adding them later is a
  one-line change.

Closes #17
