### PR TITLE
feat(magic): detect image/svg+xml from XML root element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@
 - Detect `text/xml` from leading bytes by recognizing the lowercase
   `<?xml` declaration followed by a tag-terminating byte. Both detectors
   strip an optional UTF-8 BOM and HTML whitespace before matching. (#17)
+- Detect `image/svg+xml` from the XML root element. The detector skips an
+  optional UTF-8 BOM, whitespace, an `<?xml ... ?>` prolog, an
+  `<!DOCTYPE ...>` declaration, and any number of `<!-- ... -->` comments
+  before checking for a case-sensitive `<svg` element followed by a tag
+  terminator (whitespace, `>`, `/`, or end of input). Takes priority over
+  the generic `text/xml` signature so that SVG payloads with an XML
+  prolog are reported as `image/svg+xml`. (#18)
 
 ## [0.1.0] - 2026-04-26
 

--- a/src/mimetype/internal/magic.gleam
+++ b/src/mimetype/internal/magic.gleam
@@ -110,6 +110,7 @@ const signatures = [
   Bytes("video/mp4", [#(4, <<"ftyp":utf8>>), #(8, <<"avc1":utf8>>)]),
   Check("application/json", looks_like_json),
   Check("text/html", looks_like_html),
+  Check("image/svg+xml", looks_like_svg),
   Check("text/xml", looks_like_xml),
 ]
 
@@ -517,4 +518,91 @@ fn match_byte_prefix(bytes: BitArray, prefix: BitArray) -> Result(BitArray, Nil)
 fn ascii_to_lower(byte: Int) -> Int {
   use <- bool.guard(when: byte < 0x41 || byte > 0x5A, return: byte)
   byte + 32
+}
+
+// SVG sniffing: distinguish SVG from generic XML by looking for an `<svg`
+// root element. The XML declaration, DOCTYPE, comments, and whitespace
+// between them are skipped before the root-element check so that real-world
+// SVG files (which often start with a UTF-8 BOM, an `<?xml ?>` prolog, and
+// a `<!DOCTYPE svg ...>` declaration) are recognized.
+//
+// The `<svg` match is case-sensitive: XML element names are case-sensitive
+// per the XML 1.0 spec, so `<SVG>` is not SVG. The match also requires a
+// terminator that includes `/` so that self-closing `<svg/>` works.
+//
+// Walking is bounded by `svg_sniff_budget` to cap work on pathological
+// inputs (huge comments, huge DOCTYPE, etc.).
+
+const svg_sniff_budget = 4096
+
+fn looks_like_svg(bytes: BitArray) -> Bool {
+  let bytes = trim_text_prefix(bytes)
+  let bytes = skip_xml_prolog(bytes, svg_sniff_budget)
+  let bytes = skip_xml_misc(bytes, svg_sniff_budget)
+  match_byte_prefix(bytes, <<"<svg":utf8>>)
+  |> result.map(is_xml_element_terminator)
+  |> result.unwrap(False)
+}
+
+fn is_xml_element_terminator(bytes: BitArray) -> Bool {
+  case bytes {
+    <<>> -> True
+    <<0x20, _:bits>> -> True
+    <<0x09, _:bits>> -> True
+    <<0x0A, _:bits>> -> True
+    <<0x0C, _:bits>> -> True
+    <<0x0D, _:bits>> -> True
+    <<0x3E, _:bits>> -> True
+    <<0x2F, _:bits>> -> True
+    _ -> False
+  }
+}
+
+fn skip_xml_prolog(bytes: BitArray, budget: Int) -> BitArray {
+  match_byte_prefix(bytes, <<"<?xml":utf8>>)
+  |> result.map(skip_until_literal(_, <<"?>":utf8>>, budget))
+  |> result.unwrap(bytes)
+}
+
+fn skip_xml_misc(bytes: BitArray, budget: Int) -> BitArray {
+  use <- bool.guard(when: budget <= 0, return: bytes)
+  let trimmed = skip_html_ws(bytes)
+  use <- bool.lazy_guard(
+    when: starts_with_literal(trimmed, <<"<!--":utf8>>),
+    return: fn() {
+      skip_until_literal(trimmed, <<"-->":utf8>>, budget)
+      |> skip_xml_misc(budget - 1)
+    },
+  )
+  use <- bool.lazy_guard(
+    when: starts_with_literal(trimmed, <<"<!DOCTYPE":utf8>>),
+    return: fn() {
+      skip_until_literal(trimmed, <<">":utf8>>, budget)
+      |> skip_xml_misc(budget - 1)
+    },
+  )
+  trimmed
+}
+
+fn skip_until_literal(
+  bytes: BitArray,
+  literal: BitArray,
+  budget: Int,
+) -> BitArray {
+  use <- bool.guard(when: budget <= 0, return: bytes)
+  case starts_with_literal(bytes, literal) {
+    True ->
+      match_byte_prefix(bytes, literal)
+      |> result.unwrap(bytes)
+    False ->
+      case bytes {
+        <<>> -> bytes
+        <<_, rest:bits>> -> skip_until_literal(rest, literal, budget - 1)
+        _ -> bytes
+      }
+  }
+}
+
+fn starts_with_literal(bytes: BitArray, literal: BitArray) -> Bool {
+  match_byte_prefix(bytes, literal) |> result.is_ok
 }

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -664,3 +664,69 @@ pub fn detect_html_strict_returns_ok_test() {
   mimetype.detect_strict(<<"<!DOCTYPE html>":utf8>>)
   |> should.equal(Ok("text/html"))
 }
+
+pub fn detect_svg_root_with_xmlns_test() {
+  should_detect(
+    <<
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"10\" height=\"10\"/>":utf8,
+    >>,
+    "image/svg+xml",
+  )
+}
+
+pub fn detect_svg_self_closing_test() {
+  should_detect(<<"<svg/>":utf8>>, "image/svg+xml")
+}
+
+pub fn detect_svg_after_xml_prolog_test() {
+  should_detect(<<"<?xml version=\"1.0\"?><svg></svg>":utf8>>, "image/svg+xml")
+}
+
+pub fn detect_svg_after_xml_prolog_and_doctype_test() {
+  should_detect(
+    <<
+      "<?xml version=\"1.0\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<svg>":utf8,
+    >>,
+    "image/svg+xml",
+  )
+}
+
+pub fn detect_svg_after_comment_test() {
+  should_detect(
+    <<"<?xml version=\"1.0\"?><!-- some comment --><svg/>":utf8>>,
+    "image/svg+xml",
+  )
+}
+
+pub fn detect_svg_with_utf8_bom_test() {
+  should_detect(<<0xEF, 0xBB, 0xBF, "<svg/>":utf8>>, "image/svg+xml")
+}
+
+pub fn detect_svg_with_leading_whitespace_test() {
+  should_detect(<<"   \n  <svg></svg>":utf8>>, "image/svg+xml")
+}
+
+pub fn detect_svg_truncated_root_test() {
+  should_detect(<<"<svg":utf8>>, "image/svg+xml")
+}
+
+pub fn detect_svg_rejects_uppercase_root_test() {
+  // <SVG> is not SVG (XML element names are case-sensitive). It also does
+  // not match any HTML signature, so it falls through to octet-stream.
+  should_fall_back(<<"<SVG>":utf8>>)
+}
+
+pub fn detect_svg_rejects_extended_name_test() {
+  // <svg-fake> must not match: after <svg, the next byte (-) is not a
+  // tag terminator.
+  should_fall_back(<<"<svg-fake>":utf8>>)
+}
+
+pub fn detect_svg_xml_prolog_without_svg_falls_back_to_xml_test() {
+  should_detect(<<"<?xml ?><html>":utf8>>, "text/xml")
+}
+
+pub fn detect_svg_strict_returns_ok_test() {
+  mimetype.detect_strict(<<"<svg/>":utf8>>)
+  |> should.equal(Ok("image/svg+xml"))
+}


### PR DESCRIPTION
## Summary

Recognize `image/svg+xml` by inspecting the XML root element. After
stripping an optional UTF-8 BOM, leading whitespace, an `<?xml ... ?>`
prolog, an `<!DOCTYPE ...>` declaration, and any number of `<!-- ... -->`
comments, the detector requires a case-sensitive `<svg` element followed
by a tag terminator (whitespace, `>`, `/`, or end of input). The signature
is registered before the generic `text/xml` signature so that
`<?xml ?><svg>` is reported as `image/svg+xml` rather than `text/xml`.

## Changes

- `src/mimetype/internal/magic.gleam`
  - Added `Check("image/svg+xml", looks_like_svg)` to `signatures`,
    placed immediately before the existing `Check("text/xml", ...)` so
    that SVG wins when both could match.
  - Added `looks_like_svg`, `is_xml_element_terminator`,
    `skip_xml_prolog`, `skip_xml_misc`, `skip_until_literal`, and
    `starts_with_literal`, plus a `svg_sniff_budget = 4096` cap on the
    walk so pathological inputs (huge comments, huge DOCTYPE) terminate.
  - Reused `trim_text_prefix`, `match_byte_prefix`, and `skip_html_ws`
    from #17.
- `test/mimetype_test.gleam`
  - 12 new tests under `detect_svg_*` covering: bare `<svg>`,
    self-closing `<svg/>`, `<?xml ?><svg>`, `<?xml ?><!DOCTYPE svg ...><svg>`,
    SVG after a comment, UTF-8 BOM + `<svg/>`, leading whitespace,
    truncated `<svg`, rejection of `<SVG>` (case-sensitive), rejection
    of `<svg-fake>` (terminator guard), `<?xml ?><html>` falling back to
    `text/xml`, and `detect_strict` shape.
- `CHANGELOG.md`
  - Documented the new detector under `## Unreleased`.

## Design Decisions

- **Signature order: SVG before XML.** The signature list is iterated in
  order, first match wins. If `text/xml` came first, every SVG document
  with an XML prolog would be classified as `text/xml`. Putting SVG first
  resolves this without changing the matching algorithm.
- **Case-sensitive `<svg`.** XML element names are case-sensitive per the
  XML 1.0 spec, so `<SVG>` is not SVG. Matching case-sensitively also
  prevents this signature from picking up unrelated case-insensitive
  HTML-like content.
- **Terminator includes `/`.** Real SVG files often use the self-closing
  form `<svg ... />` or `<svg/>`. The HTML/XML-decl terminator helper
  (`is_text_terminator`) intentionally omits `/` because `<a/`-style
  patterns aren't HTML signatures. SVG gets its own
  `is_xml_element_terminator` that adds `/` to the set, matching XML's
  self-closing-tag syntax.
- **Skip prolog, doctype, and arbitrary comments before the root.**
  Real-world SVG files commonly start with `<?xml ?><!DOCTYPE svg ...><svg>`,
  sometimes with comments interleaved. `skip_xml_misc` loops over
  whitespace + comments + doctype until it reaches the document element.
- **`skip_until_literal` is bounded.** Each preamble-skipping step is
  capped at `svg_sniff_budget = 4096` byte transitions. SVG files with
  multi-MB comments before the root element won't be detected, but this
  is acceptable for sniffing — real assets put the root within the first
  few hundred bytes.
- **Glinter-friendly `starts_with_literal`.** Instead of pattern-matching
  on `Result` and triggering `thrown_away_error`, the predicate
  `starts_with_literal(bytes, literal) -> Bool` wraps `match_byte_prefix
  |> result.is_ok`. This keeps the loops in `skip_xml_misc` flat under
  `bool.lazy_guard`.

## Limitations

- Inline DTDs (`<!DOCTYPE svg [ ... ]>`) with internal subsets are not
  fully parsed: `skip_until_literal(bytes, ">")` stops at the first `>`,
  which may be a `>` inside the internal subset rather than the doctype's
  closing `>`. In practice SVG files never use internal subsets, so this
  is not expected to surface.
- Comments can contain `-->`-like patterns (technically illegal per XML
  but possible in malformed input); the detector trusts the first `-->`
  it sees as the terminator.
- Like the other text-based detectors, this one only sniffs the leading
  bytes within `svg_sniff_budget`. SVGs with the `<svg>` root element
  beyond ~4 KB will not be detected; the configurable byte limit (#28)
  will be the right knob for that.

Closes #18
