### PR TITLE
feat(magic): detect TTF/OTF/TTC/WOFF/WOFF2/EOT font formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
   terminator (whitespace, `>`, `/`, or end of input). Takes priority over
   the generic `text/xml` signature so that SVG payloads with an XML
   prolog are reported as `image/svg+xml`. (#18)
+- Detect six font formats from leading-byte signatures: TrueType (`font/ttf`),
+  OpenType (`font/otf`), TrueType Collection (`font/collection`), WOFF
+  (`font/woff`), WOFF2 (`font/woff2`), and Embedded OpenType
+  (`application/vnd.ms-fontobject`). MIME types follow RFC 8081. (#22)
 
 ## [0.1.0] - 2026-04-26
 

--- a/src/mimetype/internal/magic.gleam
+++ b/src/mimetype/internal/magic.gleam
@@ -83,6 +83,15 @@ const signatures = [
     ],
   ),
   Bytes("application/vnd.apache.parquet", [#(0, <<0x50, 0x41, 0x52, 0x31>>)]),
+  Bytes("font/otf", [#(0, <<"OTTO":utf8>>)]),
+  Bytes("font/collection", [#(0, <<"ttcf":utf8>>)]),
+  Bytes("font/woff", [#(0, <<"wOFF":utf8>>)]),
+  Bytes("font/woff2", [#(0, <<"wOF2":utf8>>)]),
+  Bytes(
+    "application/vnd.ms-fontobject",
+    [#(8, <<"LP":utf8>>), #(34, <<0x00, 0x00, 0x01>>)],
+  ),
+  Bytes("font/ttf", [#(0, <<0x00, 0x01, 0x00, 0x00>>)]),
   Bytes("audio/mpeg", [#(0, <<"ID3":utf8>>)]),
   Check("audio/mpeg", has_mp3_frame_sync),
   Bytes(

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -730,3 +730,60 @@ pub fn detect_svg_strict_returns_ok_test() {
   mimetype.detect_strict(<<"<svg/>":utf8>>)
   |> should.equal(Ok("image/svg+xml"))
 }
+
+pub fn detect_ttf_test() {
+  should_detect(<<0x00, 0x01, 0x00, 0x00>>, "font/ttf")
+}
+
+pub fn detect_otf_test() {
+  should_detect(<<"OTTO":utf8>>, "font/otf")
+}
+
+pub fn detect_ttc_test() {
+  should_detect(<<"ttcf":utf8>>, "font/collection")
+}
+
+pub fn detect_woff_test() {
+  should_detect(<<"wOFF":utf8>>, "font/woff")
+}
+
+pub fn detect_woff2_test() {
+  should_detect(<<"wOF2":utf8>>, "font/woff2")
+}
+
+pub fn detect_eot_test() {
+  // EOT signature: "LP" at offset 8, "00 00 01" at offset 34.
+  let bytes = <<
+    0:size({ 8 * 8 }),
+    "LP":utf8,
+    0:size({ 24 * 8 }),
+    0x00,
+    0x00,
+    0x01,
+  >>
+  should_detect(bytes, "application/vnd.ms-fontobject")
+}
+
+pub fn detect_eot_strict_returns_ok_test() {
+  let bytes = <<
+    0:size({ 8 * 8 }),
+    "LP":utf8,
+    0:size({ 24 * 8 }),
+    0x00,
+    0x00,
+    0x01,
+  >>
+  mimetype.detect_strict(bytes)
+  |> should.equal(Ok("application/vnd.ms-fontobject"))
+}
+
+pub fn detect_eot_rejects_missing_offset_34_magic_test() {
+  // "LP" at offset 8 alone is not enough — must also have 00 00 01 at 34.
+  let bytes = <<0:size({ 8 * 8 }), "LP":utf8, 0:size({ 27 * 8 })>>
+  should_fall_back(bytes)
+}
+
+pub fn detect_font_strict_returns_ok_for_ttf_test() {
+  mimetype.detect_strict(<<0x00, 0x01, 0x00, 0x00>>)
+  |> should.equal(Ok("font/ttf"))
+}


### PR DESCRIPTION
## Summary

Recognize six font formats from their leading-byte signatures: TrueType
(TTF), OpenType (OTF), TrueType Collection (TTC), Web Open Font Format
(WOFF), Web Open Font Format 2 (WOFF2), and Embedded OpenType (EOT). All
returned MIME types follow RFC 8081 (`font/ttf`, `font/otf`,
`font/collection`, `font/woff`, `font/woff2`, and the legacy
`application/vnd.ms-fontobject` for EOT).

## Changes

- `src/mimetype/internal/magic.gleam`
  - Added six `Bytes` entries to the `signatures` const list:
    - `font/otf` — `OTTO` at offset 0
    - `font/collection` — `ttcf` at offset 0
    - `font/woff` — `wOFF` at offset 0
    - `font/woff2` — `wOF2` at offset 0
    - `application/vnd.ms-fontobject` — `LP` at offset 8 **and**
      `00 00 01` at offset 34 (multi-segment signature, EOT does not
      have a leading magic)
    - `font/ttf` — `00 01 00 00` at offset 0 (placed last in the font
      block because the magic equals TrueType's version bytes and is
      the most generic of the set)
- `test/mimetype_test.gleam`
  - Added 9 tests under `detect_ttf_test`, `detect_otf_test`,
    `detect_ttc_test`, `detect_woff_test`, `detect_woff2_test`,
    `detect_eot_test`, `detect_eot_strict_returns_ok_test`,
    `detect_eot_rejects_missing_offset_34_magic_test`, and
    `detect_font_strict_returns_ok_for_ttf_test`. The EOT tests
    construct a 37-byte fixture with the required offset markers and
    verify that the offset-34 magic is mandatory.
- `CHANGELOG.md`
  - Documented the new format coverage under `## Unreleased`.

## Design Decisions

- **Pure data additions, no new helper code.** The existing `Bytes`
  signature variant already supports both single-segment magic and
  multi-segment offset checks (used previously by AVIF/HEIC's
  `ftyp` + brand pattern), so EOT's `LP@8 + 00 00 01@34` slots in
  without any new infrastructure.
- **TTF placed after the more specific font signatures.** TTF's magic
  `00 01 00 00` is just the version bytes of any binary that begins
  with version `1.0`. Placing it last in the font block means a
  collision with a future format using the same prefix would let the
  more-specific signature win. There is no conflict against the
  current signature set.
- **MIME types per RFC 8081.** RFC 8081 registers `font/ttf`,
  `font/otf`, `font/collection`, `font/woff`, and `font/woff2` as the
  canonical IETF media types. EOT predates RFC 8081 and is registered
  as `application/vnd.ms-fontobject`, so this PR uses that legacy
  vendor MIME type.
- **No font-specific predicate.** All six formats can be identified by
  fixed-byte comparison; none requires the `Check` variant. This keeps
  the change minimal and easy to audit against the relevant specs.

## Limitations

- The TTF magic `00 01 00 00` is shared with any binary that happens to
  start with the bytes `00 01 00 00` and is not actually a TTF font.
  This false-positive rate is documented in the issue and matches the
  behavior of Go `gabriel-vasile/mimetype`. Callers needing higher
  confidence should validate the file structure themselves.
- The EOT signature does not parse the EOT header beyond the two
  fixed-offset markers. Truly malformed EOT headers that nevertheless
  happen to contain `LP` at offset 8 and `00 00 01` at offset 34 will
  be reported as EOT. Acceptable for sniffing.

Closes #22
