### PR TITLE
feat(magic): detect LZ4/lzip/Snappy/Compress/ar/LZH/zlib formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@
   (`image/vnd.radiance`), OpenEXR (`image/x-exr`), QOI (`image/x-qoi`),
   and FITS (`image/fits`). Targa (TGA) is intentionally excluded
   because its only reliable magic is at end-of-file. (#23)
+- Detect eight additional compression / archive formats: LZ4 frame and
+  legacy (`application/x-lz4`), lzip (`application/x-lzip`), Snappy
+  framed (`application/x-snappy-framed`), `.Z` compress
+  (`application/x-compress`), ar archive (`application/x-archive`),
+  LZH/LHA (`application/x-lzh-compressed`), and zlib raw streams
+  (`application/x-deflate`). The zlib detector is intentionally placed
+  last so it only fires when no other signature matched, since its
+  2-byte magic is heuristic and false-positive prone. Brotli is
+  intentionally excluded because the format has no fixed magic. (#24)
 
 ## [0.1.0] - 2026-04-26
 

--- a/src/mimetype/internal/magic.gleam
+++ b/src/mimetype/internal/magic.gleam
@@ -92,6 +92,16 @@ const signatures = [
   Bytes("application/gzip", [#(0, <<0x1F, 0x8B>>)]),
   Bytes("application/x-bzip2", [#(0, <<0x42, 0x5A, 0x68>>)]),
   Bytes("application/x-xz", [#(0, <<0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00>>)]),
+  Bytes("application/x-lz4", [#(0, <<0x04, 0x22, 0x4D, 0x18>>)]),
+  Bytes("application/x-lz4", [#(0, <<0x02, 0x21, 0x4C, 0x18>>)]),
+  Bytes("application/x-lzip", [#(0, <<"LZIP":utf8>>)]),
+  Bytes(
+    "application/x-snappy-framed",
+    [#(0, <<0xFF, 0x06, 0x00, 0x00, 0x73, 0x4E, 0x61, 0x50, 0x70, 0x59>>)],
+  ),
+  Bytes("application/x-compress", [#(0, <<0x1F, 0x9D>>)]),
+  Bytes("application/x-archive", [#(0, <<"!<arch>":utf8, 0x0A>>)]),
+  Check("application/x-lzh-compressed", has_lzh_magic),
   Bytes(
     "application/x-7z-compressed",
     [#(0, <<0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C>>)],
@@ -172,6 +182,7 @@ const signatures = [
   Check("text/html", looks_like_html),
   Check("image/svg+xml", looks_like_svg),
   Check("text/xml", looks_like_xml),
+  Check("application/x-deflate", has_zlib_magic),
 ]
 
 /// Try to recognize a MIME type from a leading byte signature.
@@ -665,4 +676,26 @@ fn skip_until_literal(
 
 fn starts_with_literal(bytes: BitArray, literal: BitArray) -> Bool {
   match_byte_prefix(bytes, literal) |> result.is_ok
+}
+
+fn has_lzh_magic(bytes: BitArray) -> Bool {
+  // LZH/LHA: `??-lh?-` where bytes 0-1 are size, 2-4 are `-lh`, 5 is the
+  // method digit, and 6 is the trailing `-`. We match the fixed parts and
+  // accept any byte at position 5.
+  has_bytes_at(bytes, 2, <<"-lh":utf8>>) && has_bytes_at(bytes, 6, <<"-":utf8>>)
+}
+
+fn has_zlib_magic(bytes: BitArray) -> Bool {
+  // RFC 1950 zlib stream: first byte 0x78 (CMF for deflate, 32K window),
+  // second byte one of the four valid (FLEVEL, FDICT) combinations whose
+  // CMF*256 + FLG is a multiple of 31. The check is heuristic — short
+  // binary inputs that happen to start with these bytes will false-positive.
+  // Placed at the end of `signatures` so this only fires when nothing else
+  // matched.
+  case bytes {
+    <<0x78, second:size(8), _:bits>>
+      if second == 0x01 || second == 0x5E || second == 0x9C || second == 0xDA
+    -> True
+    _ -> False
+  }
 }

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -837,3 +837,59 @@ pub fn detect_image_strict_returns_ok_for_psd_test() {
   mimetype.detect_strict(<<0x38, 0x42, 0x50, 0x53>>)
   |> should.equal(Ok("image/vnd.adobe.photoshop"))
 }
+
+pub fn detect_lz4_frame_test() {
+  should_detect(<<0x04, 0x22, 0x4D, 0x18>>, "application/x-lz4")
+}
+
+pub fn detect_lz4_legacy_test() {
+  should_detect(<<0x02, 0x21, 0x4C, 0x18>>, "application/x-lz4")
+}
+
+pub fn detect_lzip_test() {
+  should_detect(<<"LZIP":utf8>>, "application/x-lzip")
+}
+
+pub fn detect_snappy_framed_test() {
+  should_detect(
+    <<0xFF, 0x06, 0x00, 0x00, 0x73, 0x4E, 0x61, 0x50, 0x70, 0x59>>,
+    "application/x-snappy-framed",
+  )
+}
+
+pub fn detect_compress_test() {
+  should_detect(<<0x1F, 0x9D>>, "application/x-compress")
+}
+
+pub fn detect_ar_archive_test() {
+  should_detect(<<"!<arch>":utf8, 0x0A>>, "application/x-archive")
+}
+
+pub fn detect_lzh_method_5_test() {
+  // 2 bytes size, `-lh5-`, method byte 5, trailing `-`.
+  should_detect(<<0, 0, "-lh5-":utf8>>, "application/x-lzh-compressed")
+}
+
+pub fn detect_lzh_method_0_test() {
+  should_detect(<<0, 0, "-lh0-":utf8>>, "application/x-lzh-compressed")
+}
+
+pub fn detect_zlib_default_compression_test() {
+  // 0x78 0x9C is the most common zlib stream prefix (default compression).
+  should_detect(<<0x78, 0x9C, 0x00, 0x00>>, "application/x-deflate")
+}
+
+pub fn detect_zlib_best_compression_test() {
+  should_detect(<<0x78, 0xDA, 0x00, 0x00>>, "application/x-deflate")
+}
+
+pub fn detect_zlib_does_not_steal_png_test() {
+  // PNG bytes start with 0x89 PNG... — must NOT be detected as zlib even
+  // though PNG contains zlib internally. Verifies signature ordering.
+  should_detect(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>, "image/png")
+}
+
+pub fn detect_compression_strict_returns_ok_for_lzip_test() {
+  mimetype.detect_strict(<<"LZIP":utf8>>)
+  |> should.equal(Ok("application/x-lzip"))
+}


### PR DESCRIPTION
## Summary

Recognize eight additional compression and archive formats from leading
bytes: LZ4 (frame format and legacy), lzip, Snappy framed, `.Z` compress,
ar archive, LZH/LHA, and zlib raw streams. The zlib detector is gated
behind "no other signature matched" by being the final entry in
`signatures`, since its 2-byte magic is heuristic.

## Changes

- `src/mimetype/internal/magic.gleam`
  - Added 7 `Bytes` entries to the compression cluster (after `xz`):
    - LZ4 frame: `04 22 4D 18`
    - LZ4 legacy: `02 21 4C 18`
    - lzip: `LZIP`
    - Snappy framed: `FF 06 00 00 73 4E 61 50 70 59`
    - Compress (`.Z`): `1F 9D`
    - ar archive: `!<arch>\n`
  - Added `Check("application/x-lzh-compressed", has_lzh_magic)` for
    LZH/LHA, which has `??-lh?-` at offset 0–6 (size at 0–1, `-lh` at
    2–4, method digit at 5, trailing `-` at 6). The predicate matches
    `-lh` at offset 2 and `-` at offset 6, accepting any byte at the
    method position.
  - Added `Check("application/x-deflate", has_zlib_magic)` as the final
    entry in `signatures`. zlib's 2-byte magic (`78` + one of `01` /
    `5E` / `9C` / `DA`) is heuristic — short binary inputs that happen
    to start with these bytes will false-positive. Placement at the end
    means zlib only fires when nothing else matched, which is exactly
    the gating behavior the issue asked for.
- `test/mimetype_test.gleam`
  - 12 new tests covering each format plus a regression test
    (`detect_zlib_does_not_steal_png_test`) that verifies PNG bytes are
    still detected as `image/png` even though PNG contains zlib
    internally. This validates the signature ordering.
- `CHANGELOG.md`
  - Documented the new formats under `## Unreleased`, calling out
    Brotli's intentional exclusion (no fixed magic) and zlib's gated
    placement.

## Design Decisions

- **zlib is the final signature.** The issue suggested gating zlib
  behind "no other signature matched". Signature lookup is iterative
  with first-match-wins, so making zlib the last entry in `signatures`
  achieves the gate without any new control flow. PNG, gzip, and other
  formats that internally use zlib still resolve to their own MIME
  types because their leading magic matches first.
- **LZH uses a `Check` for the variable method byte.** LZH's signature
  is `??-lh<method>-` where `<method>` is one of about ten valid
  characters (`0`–`7`, `d`, `s`, etc.). Listing 10 separate `Bytes`
  entries would be verbose; a single `Check` matches `-lh` at offset 2
  and `-` at offset 6, accepting any byte at position 5. This matches
  what `gabriel-vasile/mimetype` does and is the right granularity for
  sniffing.
- **Brotli is intentionally excluded.** The Brotli spec deliberately
  omits a fixed magic so that streams stay small. The issue called
  this out as a known limitation; this PR documents it in the
  CHANGELOG.
- **No new helper machinery.** All seven `Bytes` entries reuse the
  existing multi-segment signature shape. The two `Check` predicates
  reuse `has_bytes_at` and the same BitArray-pattern style used by the
  existing `has_mp3_frame_sync` and `has_zstd_frame`.

## Limitations

- **zlib detection is heuristic.** Per RFC 1950, the second byte's
  validity is determined by whether `(CMF * 256 + FLG) % 31 == 0`. The
  detector accepts the four most common second-byte values
  (`01`/`5E`/`9C`/`DA`) instead of computing the modulus. False
  positives on short binary blobs are documented in the issue and
  accepted.
- **LZH method byte is not validated.** The detector accepts any byte
  at position 5. A binary input that happens to have `XX XX -lh? -` in
  the first 7 bytes (any value for the `?`) will be reported as LZH.
- **Brotli is not detected** (see above).
- **TGA is still not detected** (out of scope; tracked in #23).

Closes #24
