### PR TITLE
feat(magic): detect ASF/FLV/AAC/AMR/AC3 and split MKV from WebM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@
   last so it only fires when no other signature matched, since its
   2-byte magic is heuristic and false-positive prone. Brotli is
   intentionally excluded because the format has no fixed magic. (#24)
+- Detect additional audio/video formats: ASF / WMV / WMA
+  (`application/vnd.ms-asf`), Flash Video (`video/x-flv`), AAC ADTS and
+  AAC ADIF (both `audio/aac`), AMR (`audio/amr`), AMR-WB
+  (`audio/amr-wb`), and AC3 (`audio/ac3`). Differentiate Matroska
+  (`video/x-matroska`) from WebM (`video/webm`) by inspecting the EBML
+  DocType element within the first 256 bytes — a regression from the
+  previous behavior where any EBML magic was reported as WebM. (#25)
 
 ## [0.1.0] - 2026-04-26
 

--- a/src/mimetype/internal/magic.gleam
+++ b/src/mimetype/internal/magic.gleam
@@ -155,13 +155,32 @@ const signatures = [
   Bytes("font/ttf", [#(0, <<0x00, 0x01, 0x00, 0x00>>)]),
   Bytes("audio/mpeg", [#(0, <<"ID3":utf8>>)]),
   Check("audio/mpeg", has_mp3_frame_sync),
+  Check("audio/aac", has_aac_adts_sync),
+  Bytes("audio/aac", [#(0, <<"ADIF":utf8>>)]),
   Bytes(
     "audio/flac",
     [#(0, <<0x66, 0x4C, 0x61, 0x43, 0x00, 0x00, 0x00, 0x22>>)],
   ),
   Bytes("audio/midi", [#(0, <<0x4D, 0x54, 0x68, 0x64>>)]),
+  Bytes("audio/amr", [#(0, <<"#!AMR":utf8, 0x0A>>)]),
+  Bytes("audio/amr-wb", [#(0, <<"#!AMR-WB":utf8, 0x0A>>)]),
+  Bytes("audio/ac3", [#(0, <<0x0B, 0x77>>)]),
   Bytes("application/ogg", [#(0, <<0x4F, 0x67, 0x67, 0x53>>)]),
-  Bytes("video/webm", [#(0, <<0x1A, 0x45, 0xDF, 0xA3>>)]),
+  Bytes(
+    "application/vnd.ms-asf",
+    [
+      #(
+        0,
+        <<
+          0x30, 0x26, 0xB2, 0x75, 0x8E, 0x66, 0xCF, 0x11, 0xA6, 0xD9, 0x00, 0xAA,
+          0x00, 0x62, 0xCE, 0x6C,
+        >>,
+      ),
+    ],
+  ),
+  Bytes("video/x-flv", [#(0, <<"FLV":utf8, 0x01>>)]),
+  Check("video/x-matroska", looks_like_matroska),
+  Check("video/webm", looks_like_webm),
   Check("application/zstd", has_zstd_frame),
   Bytes("application/x-tar", [#(257, <<"ustar":utf8>>)]),
   Bytes("image/avif", [#(4, <<"ftyp":utf8>>), #(8, <<"avif":utf8>>)]),
@@ -696,6 +715,53 @@ fn has_zlib_magic(bytes: BitArray) -> Bool {
     <<0x78, second:size(8), _:bits>>
       if second == 0x01 || second == 0x5E || second == 0x9C || second == 0xDA
     -> True
+    _ -> False
+  }
+}
+
+fn has_aac_adts_sync(bytes: BitArray) -> Bool {
+  // ADTS sync = 12 bits all 1, then ID (1 bit), Layer (2 bits, must be 00),
+  // protection_absent (1 bit). Valid second-byte values (high nibble 0xF
+  // plus low nibble where bits 5-4 = 00): 0xF0, 0xF1, 0xF8, 0xF9.
+  case bytes {
+    <<0xFF, second:size(8), _:bits>>
+      if second == 0xF0 || second == 0xF1 || second == 0xF8 || second == 0xF9
+    -> True
+    _ -> False
+  }
+}
+
+const matroska_doctype = <<0x42, 0x82, 0x88, "matroska":utf8>>
+
+const webm_doctype = <<0x42, 0x82, 0x84, "webm":utf8>>
+
+const ebml_search_budget = 256
+
+fn looks_like_matroska(bytes: BitArray) -> Bool {
+  case bytes {
+    <<0x1A, 0x45, 0xDF, 0xA3, _:bits>> ->
+      contains_literal(bytes, matroska_doctype, ebml_search_budget)
+    _ -> False
+  }
+}
+
+fn looks_like_webm(bytes: BitArray) -> Bool {
+  case bytes {
+    <<0x1A, 0x45, 0xDF, 0xA3, _:bits>> ->
+      contains_literal(bytes, webm_doctype, ebml_search_budget)
+    _ -> False
+  }
+}
+
+fn contains_literal(bytes: BitArray, literal: BitArray, budget: Int) -> Bool {
+  use <- bool.guard(when: budget <= 0, return: False)
+  use <- bool.lazy_guard(
+    when: starts_with_literal(bytes, literal),
+    return: fn() { True },
+  )
+  case bytes {
+    <<>> -> False
+    <<_, rest:bits>> -> contains_literal(rest, literal, budget - 1)
     _ -> False
   }
 }

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -304,7 +304,8 @@ pub fn detect_runtime_and_container_formats_test() {
   should_detect(<<0x7F, 0x45, 0x4C, 0x46>>, "application/x-elf")
   should_detect(<<"PAR1":utf8>>, "application/vnd.apache.parquet")
   should_detect(<<"OggS":utf8>>, "application/ogg")
-  should_detect(<<0x1A, 0x45, 0xDF, 0xA3>>, "video/webm")
+  // WebM/Matroska detection now requires the EBML DocType element, not just
+  // the EBML magic — see `detect_webm_test` and `detect_matroska_test`.
 }
 
 pub fn detect_audio_formats_test() {
@@ -892,4 +893,67 @@ pub fn detect_zlib_does_not_steal_png_test() {
 pub fn detect_compression_strict_returns_ok_for_lzip_test() {
   mimetype.detect_strict(<<"LZIP":utf8>>)
   |> should.equal(Ok("application/x-lzip"))
+}
+
+pub fn detect_aac_adts_test() {
+  // ADTS sync: 0xFF then 0xF0/F1/F8/F9.
+  should_detect(<<0xFF, 0xF1, 0x00, 0x00>>, "audio/aac")
+}
+
+pub fn detect_aac_adif_test() {
+  should_detect(<<"ADIF":utf8>>, "audio/aac")
+}
+
+pub fn detect_amr_test() {
+  should_detect(<<"#!AMR":utf8, 0x0A, 0x00, 0x00>>, "audio/amr")
+}
+
+pub fn detect_amr_wb_test() {
+  should_detect(<<"#!AMR-WB":utf8, 0x0A, 0x00, 0x00>>, "audio/amr-wb")
+}
+
+pub fn detect_ac3_test() {
+  should_detect(<<0x0B, 0x77, 0x00, 0x00>>, "audio/ac3")
+}
+
+pub fn detect_asf_test() {
+  should_detect(
+    <<
+      0x30, 0x26, 0xB2, 0x75, 0x8E, 0x66, 0xCF, 0x11, 0xA6, 0xD9, 0x00, 0xAA,
+      0x00, 0x62, 0xCE, 0x6C,
+    >>,
+    "application/vnd.ms-asf",
+  )
+}
+
+pub fn detect_flv_test() {
+  should_detect(<<"FLV":utf8, 0x01, 0x05>>, "video/x-flv")
+}
+
+pub fn detect_matroska_test() {
+  // EBML magic + DocType element (0x4282) + length 0x88 + "matroska".
+  let bytes = <<
+    0x1A, 0x45, 0xDF, 0xA3, 0x9F, 0x42, 0x86, 0x81, 0x01, 0x42, 0xF7, 0x81, 0x01,
+    0x42, 0x82, 0x88, "matroska":utf8,
+  >>
+  should_detect(bytes, "video/x-matroska")
+}
+
+pub fn detect_webm_test() {
+  // EBML magic + DocType element (0x4282) + length 0x84 + "webm".
+  let bytes = <<
+    0x1A, 0x45, 0xDF, 0xA3, 0x9F, 0x42, 0x86, 0x81, 0x01, 0x42, 0xF7, 0x81, 0x01,
+    0x42, 0x82, 0x84, "webm":utf8,
+  >>
+  should_detect(bytes, "video/webm")
+}
+
+pub fn detect_ebml_without_doctype_falls_back_test() {
+  // EBML magic alone (no matroska/webm DocType in budget) → falls back.
+  should_fall_back(<<0x1A, 0x45, 0xDF, 0xA3, 0x9F, 0x42, 0x86, 0x81, 0x01>>)
+}
+
+pub fn detect_av_strict_returns_ok_for_amr_test() {
+  mimetype.detect_strict(<<"#!AMR":utf8, 0x0A>>)
+  |> should.equal(Ok("audio/amr"))
 }


### PR DESCRIPTION
## Summary

Recognize seven additional audio/video formats and differentiate Matroska
(MKV) from WebM by inspecting the EBML DocType element. Pure data
additions for the simple formats; a lightweight EBML byte search for the
MKV/WebM split.

## Changes

- `src/mimetype/internal/magic.gleam`
  - Added 6 new `Bytes` entries:
    - ASF / WMV / WMA: 16-byte GUID `30 26 B2 75 ... CE 6C` →
      `application/vnd.ms-asf`
    - FLV: `FLV\x01` → `video/x-flv`
    - AAC ADIF: `ADIF` → `audio/aac`
    - AMR: `#!AMR\n` → `audio/amr`
    - AMR-WB: `#!AMR-WB\n` → `audio/amr-wb`
    - AC3: `0B 77` → `audio/ac3`
  - Added 3 new `Check` entries:
    - `Check("audio/aac", has_aac_adts_sync)` — 12-bit ADTS sync
      (`0xFF` then second byte `0xF0`/`0xF1`/`0xF8`/`0xF9` for the
      valid ID/Layer/protection_absent combinations)
    - `Check("video/x-matroska", looks_like_matroska)` — EBML magic
      plus the DocType element `42 82 88 matroska` within the first
      256 bytes
    - `Check("video/webm", looks_like_webm)` — EBML magic plus the
      DocType element `42 82 84 webm` within the first 256 bytes
  - Removed `Bytes("video/webm", [#(0, <<0x1A, 0x45, 0xDF, 0xA3>>)])`
    in favor of the new `Check`. **This is a behavior change**: EBML
    files without the WebM DocType (including raw MKV files that
    previously fell through this signature first) are now classified
    correctly. EBML files with neither `webm` nor `matroska` DocType
    fall back to `application/octet-stream`.
  - Added the `contains_literal` helper, the `matroska_doctype` /
    `webm_doctype` BitArray constants, and the
    `ebml_search_budget = 256` cap.
- `test/mimetype_test.gleam`
  - Added 11 new tests under `detect_aac_adts_test`,
    `detect_aac_adif_test`, `detect_amr_test`, `detect_amr_wb_test`,
    `detect_ac3_test`, `detect_asf_test`, `detect_flv_test`,
    `detect_matroska_test`, `detect_webm_test`,
    `detect_ebml_without_doctype_falls_back_test`, and
    `detect_av_strict_returns_ok_for_amr_test`. The matroska/webm
    fixtures synthesize the EBML header bytes and DocType element
    bytes directly.
  - Updated `detect_runtime_and_container_formats_test` to remove the
    "any EBML magic → WebM" assertion, with a note pointing to the
    new strict tests.
- `CHANGELOG.md`
  - Documented the new format coverage and the MKV/WebM split,
    explicitly calling out the WebM behavior change.

## Design Decisions

- **MKV vs WebM via EBML DocType byte search.** Walking the full EBML
  variable-length-integer structure to extract the DocType element is
  significantly more code than a byte-level search for the literal
  `42 82 8N <name>` (where `8N` is the length-prefix byte). Per the
  EBML spec, DocType IDs (`42 82`) followed by a tag-length byte and
  the literal `matroska` (length 0x88 = 8 bytes) or `webm` (length
  0x84 = 4 bytes) is unambiguous in any well-formed EBML file. This
  matches what `gabriel-vasile/mimetype` does and is sufficient for
  sniffing.
- **AAC ADTS sync uses bit-level constraints encoded in the second
  byte.** The 12-bit ADTS sync (`1111 1111 1111`) plus the required
  `Layer == 00` constraint reduces the second byte to four valid
  values (`F0`/`F1`/`F8`/`F9`). This avoids overlap with MP3 frame
  sync (`FB`/`FA`/`F3`/`F2`), JPEG (`D8`), and JPEG XL (`0A`).
- **AAC ADTS check is placed after MP3.** Both are `0xFF`-prefixed
  audio sync words. They are mutually exclusive on the second byte,
  so order doesn't affect correctness, but listing AAC after MP3
  keeps the audio cluster organized by historical adoption.
- **AC3 is just `0B 77`.** Two bytes is short and false-positive
  prone. The issue accepts this; gating behind ID3 or filename hints
  is out of scope.
- **ASF returns `application/vnd.ms-asf`, not WMV/WMA specifically.**
  ASF is the container format; WMV (video) and WMA (audio) share the
  same outer GUID magic. Without parsing the ASF object tree to find
  the stream type, the most accurate report is the parent type. The
  `detect_with_filename` API can refine this when an extension hint
  is available.
- **Reused the `contains_literal` helper for MKV/WebM.** The same
  byte-search pattern that powers `skip_until_literal` (used for SVG
  prolog/comment skipping) drives the MKV/WebM DocType search,
  bounded by `ebml_search_budget = 256`.

## Limitations

- **EBML files with neither `webm` nor `matroska` DocType fall back
  to octet-stream.** The previous "any EBML = WebM" behavior was a
  false positive for any non-WebM EBML file (the format is also used
  for MKA, WebM-derived formats, and other niche containers). Strict
  detection trades the convenience of catch-all WebM for correctness.
- **EAC3 is not differentiated from AC3.** The issue's proposal
  required reading the bsid field in the AC3 sync header, which is
  not a fixed-byte check. Both formats are reported as `audio/ac3`
  for now.
- **AAC ADTS is heuristic.** A binary input that happens to start
  with `0xFF` then one of the four valid second-byte values will
  false-positive. Real AAC streams almost always carry an ID3 header
  first (which is matched earlier).
- **ASF / WMV / WMA cannot be distinguished without filename hints.**
  All three return `application/vnd.ms-asf`. Callers using
  `detect_with_filename` get refinement via the extension lookup.

Closes #25


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended MIME type detection support for audio formats: AAC (ADTS and ADIF variants), AMR, AMR-WB, and AC3
  * Added detection for media container formats: ASF/WMV/WMA, FLV, Matroska, and WebM
  * Improved Matroska and WebM format differentiation for more accurate media identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->