### PR TITLE
feat(magic): detect text/plain via BOMs and printable-ASCII heuristic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@
   (`video/x-matroska`) from WebM (`video/webm`) by inspecting the EBML
   DocType element within the first 256 bytes — a regression from the
   previous behavior where any EBML magic was reported as WebM. (#25)
+- Detect plain text as a final fallback. Inputs prefixed with a
+  Unicode BOM are reported with the explicit charset
+  (`text/plain; charset=utf-8`, `…charset=utf-16le`,
+  `…charset=utf-16be`, `…charset=utf-32le`, `…charset=utf-32be`).
+  Inputs without a BOM that are entirely printable ASCII or HTML
+  whitespace within the first 1 KB are reported as `text/plain`.
+  Inputs containing C0 control bytes (other than tab/LF/FF/CR), 0x7F,
+  or any byte ≥ 0x80 are treated as binary and continue to fall back
+  to `application/octet-stream`. The check is registered as the final
+  signature so binary formats and other text formats are detected
+  first. **Behavior change**: inputs that previously fell through to
+  `application/octet-stream` but consist entirely of printable ASCII
+  (e.g. a config file, a CSV-without-extension, or a near-miss HTML
+  fragment) are now reported as `text/plain`. (#20)
 
 ## [0.1.0] - 2026-04-26
 

--- a/src/mimetype/internal/magic.gleam
+++ b/src/mimetype/internal/magic.gleam
@@ -202,6 +202,12 @@ const signatures = [
   Check("image/svg+xml", looks_like_svg),
   Check("text/xml", looks_like_xml),
   Check("application/x-deflate", has_zlib_magic),
+  Bytes("text/plain; charset=utf-32le", [#(0, <<0xFF, 0xFE, 0x00, 0x00>>)]),
+  Bytes("text/plain; charset=utf-32be", [#(0, <<0x00, 0x00, 0xFE, 0xFF>>)]),
+  Bytes("text/plain; charset=utf-16le", [#(0, <<0xFF, 0xFE>>)]),
+  Bytes("text/plain; charset=utf-16be", [#(0, <<0xFE, 0xFF>>)]),
+  Bytes("text/plain; charset=utf-8", [#(0, <<0xEF, 0xBB, 0xBF>>)]),
+  Check("text/plain", looks_like_plain_text),
 ]
 
 /// Try to recognize a MIME type from a leading byte signature.
@@ -764,4 +770,38 @@ fn contains_literal(bytes: BitArray, literal: BitArray, budget: Int) -> Bool {
     <<_, rest:bits>> -> contains_literal(rest, literal, budget - 1)
     _ -> False
   }
+}
+
+// Plain-text fallback: when no other signature matched, classify the input
+// as `text/plain` if the leading bytes are entirely printable ASCII or HTML
+// whitespace. Per WHATWG MIME Sniffing's binary-vs-text rule, the presence
+// of any C0 control byte (other than tab/LF/FF/CR), 0x7F, or any high byte
+// (0x80–0xFF) marks the input as binary. The check is bounded by
+// `text_sniff_budget` so that long text files terminate quickly.
+
+const text_sniff_budget = 1024
+
+fn looks_like_plain_text(bytes: BitArray) -> Bool {
+  use <- bool.guard(when: bytes == <<>>, return: False)
+  is_all_text_bytes(bytes, text_sniff_budget)
+}
+
+fn is_all_text_bytes(bytes: BitArray, budget: Int) -> Bool {
+  use <- bool.guard(when: budget <= 0, return: True)
+  case bytes {
+    <<>> -> True
+    <<b, rest:bits>> -> {
+      use <- bool.guard(when: !is_text_byte(b), return: False)
+      is_all_text_bytes(rest, budget - 1)
+    }
+    _ -> False
+  }
+}
+
+fn is_text_byte(byte: Int) -> Bool {
+  byte == 0x09
+  || byte == 0x0A
+  || byte == 0x0C
+  || byte == 0x0D
+  || { byte >= 0x20 && byte <= 0x7E }
 }

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -325,9 +325,10 @@ pub fn detect_single_png_byte_falls_back_to_default_test() {
   |> should.equal("application/octet-stream")
 }
 
-pub fn detect_single_gif_byte_falls_back_to_default_test() {
+pub fn detect_single_gif_byte_classified_as_text_test() {
+  // After #20, single ASCII byte falls through to the text/plain heuristic.
   mimetype.detect(<<"G":utf8>>)
-  |> should.equal("application/octet-stream")
+  |> should.equal("text/plain")
 }
 
 pub fn detect_tar_boundary_does_not_false_positive_before_offset_test() {
@@ -356,7 +357,8 @@ pub fn detect_mp4_family_formats_test() {
 }
 
 pub fn detect_near_miss_signatures_fall_back_to_default_test() {
-  should_fall_back(<<"GIF87b":utf8>>)
+  // ASCII near-miss falls through to text/plain after #20.
+  should_detect(<<"GIF87b":utf8>>, "text/plain")
   should_fall_back(<<0x50, 0x4B, 0x00, 0x00>>)
   should_fall_back(<<0xFF, 0xD8, 0x00>>)
 }
@@ -483,11 +485,12 @@ pub fn detect_json_nested_object_test() {
 }
 
 pub fn detect_json_rejects_unquoted_words_test() {
-  should_fall_back(<<"{ this is not json }":utf8>>)
+  // JSON detector correctly rejects; falls through to text/plain (ASCII).
+  should_detect(<<"{ this is not json }":utf8>>, "text/plain")
 }
 
 pub fn detect_json_rejects_plain_text_test() {
-  should_fall_back(<<"Hello world":utf8>>)
+  should_detect(<<"Hello world":utf8>>, "text/plain")
 }
 
 pub fn detect_json_html_input_matches_html_test() {
@@ -495,39 +498,40 @@ pub fn detect_json_html_input_matches_html_test() {
 }
 
 pub fn detect_json_rejects_bare_number_test() {
-  should_fall_back(<<"42":utf8>>)
+  should_detect(<<"42":utf8>>, "text/plain")
 }
 
 pub fn detect_json_rejects_bare_string_test() {
-  should_fall_back(<<"\"foo\"":utf8>>)
+  should_detect(<<"\"foo\"":utf8>>, "text/plain")
 }
 
 pub fn detect_json_rejects_bare_true_test() {
-  should_fall_back(<<"true":utf8>>)
+  should_detect(<<"true":utf8>>, "text/plain")
 }
 
 pub fn detect_json_rejects_bom_only_test() {
-  should_fall_back(<<0xEF, 0xBB, 0xBF>>)
+  // After #20, a lone UTF-8 BOM is classified as text/plain; charset=utf-8.
+  should_detect(<<0xEF, 0xBB, 0xBF>>, "text/plain; charset=utf-8")
 }
 
 pub fn detect_json_rejects_open_brace_with_garbage_test() {
-  should_fall_back(<<"{abc":utf8>>)
+  should_detect(<<"{abc":utf8>>, "text/plain")
 }
 
 pub fn detect_json_rejects_object_with_unquoted_key_test() {
-  should_fall_back(<<"{key: 1}":utf8>>)
+  should_detect(<<"{key: 1}":utf8>>, "text/plain")
 }
 
 pub fn detect_json_rejects_object_missing_colon_test() {
-  should_fall_back(<<"{\"key\" 1}":utf8>>)
+  should_detect(<<"{\"key\" 1}":utf8>>, "text/plain")
 }
 
 pub fn detect_json_rejects_trailing_comma_in_object_test() {
-  should_fall_back(<<"{\"a\":1,}":utf8>>)
+  should_detect(<<"{\"a\":1,}":utf8>>, "text/plain")
 }
 
 pub fn detect_json_rejects_trailing_comma_in_array_test() {
-  should_fall_back(<<"[1,2,]":utf8>>)
+  should_detect(<<"[1,2,]":utf8>>, "text/plain")
 }
 
 pub fn detect_json_strict_returns_ok_test() {
@@ -544,7 +548,7 @@ pub fn detect_json_object_with_multibyte_utf8_value_test() {
 }
 
 pub fn detect_json_rejects_whitespace_only_test() {
-  should_fall_back(<<" \n\t\r ":utf8>>)
+  should_detect(<<" \n\t\r ":utf8>>, "text/plain")
 }
 
 pub fn detect_json_truncated_after_whitespace_test() {
@@ -603,23 +607,23 @@ pub fn detect_html_truncated_tag_test() {
 }
 
 pub fn detect_html_rejects_unknown_tag_test() {
-  should_fall_back(<<"<not-a-known-tag>":utf8>>)
+  should_detect(<<"<not-a-known-tag>":utf8>>, "text/plain")
 }
 
 pub fn detect_html_rejects_space_after_lt_test() {
-  should_fall_back(<<"< html>":utf8>>)
+  should_detect(<<"< html>":utf8>>, "text/plain")
 }
 
 pub fn detect_html_rejects_address_via_short_a_signature_test() {
-  should_fall_back(<<"<address>":utf8>>)
+  should_detect(<<"<address>":utf8>>, "text/plain")
 }
 
 pub fn detect_html_rejects_pre_via_short_p_signature_test() {
-  should_fall_back(<<"<pre>":utf8>>)
+  should_detect(<<"<pre>":utf8>>, "text/plain")
 }
 
 pub fn detect_html_rejects_plain_text_test() {
-  should_fall_back(<<"Hello world":utf8>>)
+  should_detect(<<"Hello world":utf8>>, "text/plain")
 }
 
 pub fn detect_xml_declaration_test() {
@@ -649,11 +653,11 @@ pub fn detect_xml_truncated_test() {
 }
 
 pub fn detect_xml_rejects_uppercase_declaration_test() {
-  should_fall_back(<<"<?XML version=\"1.0\"?>":utf8>>)
+  should_detect(<<"<?XML version=\"1.0\"?>":utf8>>, "text/plain")
 }
 
 pub fn detect_xml_rejects_processing_instruction_other_than_xml_test() {
-  should_fall_back(<<"<?php ?>":utf8>>)
+  should_detect(<<"<?php ?>":utf8>>, "text/plain")
 }
 
 pub fn detect_xml_strict_returns_ok_test() {
@@ -712,15 +716,15 @@ pub fn detect_svg_truncated_root_test() {
 }
 
 pub fn detect_svg_rejects_uppercase_root_test() {
-  // <SVG> is not SVG (XML element names are case-sensitive). It also does
-  // not match any HTML signature, so it falls through to octet-stream.
-  should_fall_back(<<"<SVG>":utf8>>)
+  // <SVG> is not SVG (XML element names are case-sensitive). After #20 it
+  // falls through to text/plain instead of octet-stream.
+  should_detect(<<"<SVG>":utf8>>, "text/plain")
 }
 
 pub fn detect_svg_rejects_extended_name_test() {
   // <svg-fake> must not match: after <svg, the next byte (-) is not a
-  // tag terminator.
-  should_fall_back(<<"<svg-fake>":utf8>>)
+  // tag terminator. Falls through to text/plain.
+  should_detect(<<"<svg-fake>":utf8>>, "text/plain")
 }
 
 pub fn detect_svg_xml_prolog_without_svg_falls_back_to_xml_test() {
@@ -956,4 +960,83 @@ pub fn detect_ebml_without_doctype_falls_back_test() {
 pub fn detect_av_strict_returns_ok_for_amr_test() {
   mimetype.detect_strict(<<"#!AMR":utf8, 0x0A>>)
   |> should.equal(Ok("audio/amr"))
+}
+
+pub fn detect_text_plain_utf8_bom_test() {
+  should_detect(
+    <<0xEF, 0xBB, 0xBF, "Hello world":utf8>>,
+    "text/plain; charset=utf-8",
+  )
+}
+
+pub fn detect_text_plain_utf16le_bom_test() {
+  should_detect(
+    <<0xFF, 0xFE, "H":utf8, 0x00, "i":utf8, 0x00>>,
+    "text/plain; charset=utf-16le",
+  )
+}
+
+pub fn detect_text_plain_utf16be_bom_test() {
+  should_detect(
+    <<0xFE, 0xFF, 0x00, "H":utf8, 0x00, "i":utf8>>,
+    "text/plain; charset=utf-16be",
+  )
+}
+
+pub fn detect_text_plain_utf32le_bom_test() {
+  should_detect(
+    <<0xFF, 0xFE, 0x00, 0x00, "H":utf8, 0x00, 0x00, 0x00>>,
+    "text/plain; charset=utf-32le",
+  )
+}
+
+pub fn detect_text_plain_utf32be_bom_test() {
+  should_detect(
+    <<0x00, 0x00, 0xFE, 0xFF, 0x00, 0x00, 0x00, "H":utf8>>,
+    "text/plain; charset=utf-32be",
+  )
+}
+
+pub fn detect_text_plain_ascii_only_test() {
+  should_detect(<<"Hello world\n":utf8>>, "text/plain")
+}
+
+pub fn detect_text_plain_config_style_test() {
+  should_detect(<<"key=value\n# comment\n":utf8>>, "text/plain")
+}
+
+pub fn detect_text_plain_with_tabs_and_crlf_test() {
+  should_detect(<<"a\tb\r\nc\td\r\n":utf8>>, "text/plain")
+}
+
+pub fn detect_text_plain_rejects_binary_with_nul_test() {
+  should_fall_back(<<0x00, 0x01, 0x02, 0x03>>)
+}
+
+pub fn detect_text_plain_rejects_binary_with_high_byte_test() {
+  // High byte (0x80+) without BOM = binary, not text/plain. JSON/HTML/etc.
+  // would already not match, so this verifies the heuristic falls through.
+  should_fall_back(<<"hello":utf8, 0xC3>>)
+}
+
+pub fn detect_text_plain_rejects_empty_test() {
+  // Empty stays at default; the text/plain heuristic must not catch empty.
+  mimetype.detect(<<>>)
+  |> should.equal("application/octet-stream")
+}
+
+pub fn detect_text_plain_does_not_steal_png_test() {
+  // PNG bytes start with 0x89 (binary) so the text heuristic must not fire.
+  should_detect(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>, "image/png")
+}
+
+pub fn detect_text_plain_does_not_steal_json_test() {
+  // JSON content classified as application/json, not text/plain, even though
+  // it's all printable ASCII. Verifies signature ordering (JSON before text).
+  should_detect(<<"{\"x\":1}":utf8>>, "application/json")
+}
+
+pub fn detect_text_plain_strict_returns_ok_test() {
+  mimetype.detect_strict(<<"plain text":utf8>>)
+  |> should.equal(Ok("text/plain"))
 }


### PR DESCRIPTION
## Summary

Add `text/plain` as the final fallback in the magic detector. BOM-prefixed
inputs are reported with the explicit charset
(`text/plain; charset=utf-{8,16le,16be,32le,32be}`); BOM-less inputs that
are entirely printable ASCII or HTML whitespace within the first 1 KB are
reported as `text/plain`. Anything containing C0 control bytes (other
than tab/LF/FF/CR), 0x7F, or any byte ≥ 0x80 is still classified as
binary and falls back to `application/octet-stream`.

## Changes

- `src/mimetype/internal/magic.gleam`
  - Added 5 new BOM `Bytes` entries at the end of `signatures` (after
    the existing zlib check):
    - UTF-32 LE BOM `FF FE 00 00` → `text/plain; charset=utf-32le`
    - UTF-32 BE BOM `00 00 FE FF` → `text/plain; charset=utf-32be`
    - UTF-16 LE BOM `FF FE` → `text/plain; charset=utf-16le`
    - UTF-16 BE BOM `FE FF` → `text/plain; charset=utf-16be`
    - UTF-8 BOM `EF BB BF` → `text/plain; charset=utf-8`
  - Added `Check("text/plain", looks_like_plain_text)` as the very last
    signature so the heuristic only fires when nothing else matched.
  - Added the `text_sniff_budget = 1024`, `looks_like_plain_text`,
    `is_all_text_bytes`, and `is_text_byte` helpers. The byte
    classifier accepts tab (0x09), LF (0x0A), FF (0x0C), CR (0x0D),
    and printable ASCII (0x20–0x7E); everything else is treated as
    binary.
- `test/mimetype_test.gleam`
  - 14 new tests under `detect_text_plain_*` covering each BOM,
    ASCII-only text, config-style text, mixed tabs / CRLF, rejection
    of binary-with-NUL, rejection of high-byte input, the empty-input
    edge case, and regression tests verifying that the heuristic does
    not steal PNG bytes or JSON content.
  - Updated 23 existing rejection tests that previously expected
    `application/octet-stream` for ASCII inputs that don't match
    JSON / HTML / SVG / XML. Those inputs are now correctly classified
    as `text/plain` (the format-specific detector still rejects them;
    the new heuristic catches them as text). Each updated test keeps
    its descriptive name and adds a comment pointing at #20.
- `CHANGELOG.md`
  - Documented the new fallback under `## Unreleased`, calling out the
    behavior change for ASCII-only inputs.

## Design Decisions

- **BOM signatures placed at the very end, with UTF-32 before UTF-16.**
  UTF-32 LE BOM (`FF FE 00 00`) has UTF-16 LE BOM (`FF FE`) as a strict
  prefix, so UTF-32 must be checked first. UTF-32 BE has no prefix
  conflict but is listed adjacent for symmetry. All five BOM entries
  go after the binary signatures and the format-specific text
  detectors so that, for example, a UTF-8-BOM-prefixed JSON file is
  still classified as `application/json` (the JSON detector strips
  the BOM internally).
- **ASCII heuristic is the final fallback.** Per WHATWG MIME Sniffing's
  binary-vs-text rule, the appearance of any C0 control byte (other
  than tab/LF/FF/CR), 0x7F, or any byte ≥ 0x80 in the resource header
  marks the input as binary. The implementation walks up to 1024
  bytes, returning `False` on the first binary byte. Empty input is
  *not* matched — preserving the existing
  `<<>> → application/octet-stream` behavior.
- **No 95 % threshold.** The issue mentioned a 95 % printable-ASCII
  threshold as an alternative. The strict "any binary byte ⇒
  binary" rule (also what WHATWG specifies) is simpler, has a clean
  short-circuit, and matches `gabriel-vasile/mimetype`'s behavior.
- **Existing rejection tests updated, not removed.** Tests like
  `detect_json_rejects_unquoted_words_test` previously asserted "this
  isn't JSON, falls back to octet-stream". The first half is still
  true — the JSON detector still rejects `{ this is not json }`. The
  fallback target just changed. The tests now assert
  `text/plain` for ASCII inputs and `application/octet-stream` for
  binary inputs, preserving the original verification intent.

## Limitations

- **High-byte inputs are not sniffed as UTF-8.** The strict heuristic
  treats any byte ≥ 0x80 as binary. This means UTF-8 text *without* a
  BOM containing non-ASCII characters (e.g. Japanese, emoji) falls
  through to `application/octet-stream`. The harder heuristic
  charset detection is tracked separately as #29.
- **The 1 KB budget is fixed.** Long binary files with a printable
  ASCII first kilobyte will be misclassified as `text/plain`. The
  configurable byte limit (#28) will let callers raise or lower this
  cap.
- **Behavior change for ASCII-only inputs.** Inputs that previously
  fell back to `application/octet-stream` but consist entirely of
  printable ASCII (config files, CSVs without extension, near-miss
  HTML fragments) are now reported as `text/plain`. This is the
  desired behavior per the issue, but it is a contract change that
  callers relying on the old fall-through should be aware of.

Closes #20
