### PR TITLE
feat: add detect_with_limit for configurable inspection window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@
   (`video/x-matroska`) from WebM (`video/webm`) by inspecting the EBML
   DocType element within the first 256 bytes — a regression from the
   previous behavior where any EBML magic was reported as WebM. (#25)
+- Add `detect_with_limit` and `detect_with_limit_strict` plus the
+  `default_detection_limit = 3072` constant. Callers can now bound
+  the number of leading bytes the detector inspects, matching the
+  knob Go's `gabriel-vasile/mimetype` exposes via `SetLimit`. The
+  existing `detect`/`detect_strict` continue to work and are now
+  defined as `detect_with_limit(_, default_detection_limit)`. (#28)
 - Detect plain text as a final fallback. Inputs prefixed with a
   Unicode BOM are reported with the explicit charset
   (`text/plain; charset=utf-8`, `…charset=utf-16le`,

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -6,9 +6,11 @@
 //// - combined helpers, which prefer content-based detection and fall
 ////   back to metadata when the byte signature is unknown
 
+import gleam/bit_array
 import gleam/bool
 import gleam/list
 import gleam/option.{type Option, None, Some}
+import gleam/result
 import gleam/string
 import mimetype/internal/db
 import mimetype/internal/magic
@@ -16,6 +18,17 @@ import mimetype/internal/magic
 /// Fallback MIME type used when neither metadata nor byte signatures
 /// provide a more specific answer.
 pub const default_mime_type = db.default_mime_type
+
+/// Default upper bound on the number of leading bytes inspected by
+/// `detect` and `detect_strict`.
+///
+/// 3072 bytes is large enough for every signature this library ships
+/// (the largest fixed-offset check is `application/x-tar` at offset
+/// 257, plus envelope formats like ZIP central-directory inspection
+/// reach into the first few KB) and matches the default used by Go's
+/// `gabriel-vasile/mimetype` library. Pass an explicit limit via
+/// `detect_with_limit` / `detect_with_limit_strict` to override.
+pub const default_detection_limit = 3072
 
 /// Look up a MIME type from a file extension.
 ///
@@ -164,10 +177,7 @@ pub fn filename_to_mime_type_strict(path: String) -> Result(String, Nil) {
 /// If no signature matches, the default fallback MIME type is
 /// returned.
 pub fn detect(bytes: BitArray) -> String {
-  case detect_strict(bytes) {
-    Ok(mime_type) -> mime_type
-    Error(Nil) -> default_mime_type
-  }
+  detect_with_limit(bytes, default_detection_limit)
 }
 
 /// Detect a MIME type from the leading bytes of a blob.
@@ -175,7 +185,41 @@ pub fn detect(bytes: BitArray) -> String {
 /// This strict variant returns `Error(Nil)` when no supported
 /// magic-number signature matches.
 pub fn detect_strict(bytes: BitArray) -> Result(String, Nil) {
-  result_from_option(magic.detect(bytes))
+  detect_with_limit_strict(bytes, default_detection_limit)
+}
+
+/// Detect a MIME type from the leading bytes of a blob, examining at
+/// most `limit` bytes from the start of the input.
+///
+/// A non-positive `limit` is treated as zero, in which case no
+/// signature can match and the fallback MIME type is returned.
+/// Limits larger than the input are clamped to the input length.
+pub fn detect_with_limit(bytes: BitArray, limit: Int) -> String {
+  case detect_with_limit_strict(bytes, limit) {
+    Ok(mime_type) -> mime_type
+    Error(Nil) -> default_mime_type
+  }
+}
+
+/// Detect a MIME type from at most `limit` leading bytes.
+///
+/// Strict variant; returns `Error(Nil)` when no supported signature
+/// matches within the limit.
+pub fn detect_with_limit_strict(
+  bytes: BitArray,
+  limit: Int,
+) -> Result(String, Nil) {
+  result_from_option(magic.detect(truncate_to_limit(bytes, limit)))
+}
+
+fn truncate_to_limit(bytes: BitArray, limit: Int) -> BitArray {
+  let size = bit_array.byte_size(bytes)
+  let safe_limit = case limit < 0, limit > size {
+    True, _ -> 0
+    False, True -> size
+    False, False -> limit
+  }
+  bit_array.slice(bytes, 0, safe_limit) |> result.unwrap(<<>>)
 }
 
 /// Detect a MIME type from bytes, falling back to an explicit

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -1040,3 +1040,89 @@ pub fn detect_text_plain_strict_returns_ok_test() {
   mimetype.detect_strict(<<"plain text":utf8>>)
   |> should.equal(Ok("text/plain"))
 }
+
+pub fn detect_with_limit_png_within_limit_test() {
+  // PNG signature is 8 bytes; a limit of exactly 8 must match.
+  mimetype.detect_with_limit(
+    <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>,
+    8,
+  )
+  |> should.equal("image/png")
+}
+
+pub fn detect_with_limit_tar_below_offset_test() {
+  // TAR `ustar` magic sits at offset 257; a limit of 256 must cut it off.
+  let bytes = <<0:size({ 257 * 8 }), 0x75, 0x73, 0x74, 0x61, 0x72, 0:size(64)>>
+  mimetype.detect_with_limit(bytes, 256)
+  |> should.equal("application/octet-stream")
+}
+
+pub fn detect_with_limit_tar_above_offset_test() {
+  let bytes = <<0:size({ 257 * 8 }), 0x75, 0x73, 0x74, 0x61, 0x72, 0:size(64)>>
+  mimetype.detect_with_limit(bytes, 512)
+  |> should.equal("application/x-tar")
+}
+
+pub fn detect_with_limit_zip_within_4_bytes_test() {
+  // ZIP local file header `50 4B 03 04` fits in 4 bytes.
+  mimetype.detect_with_limit(<<0x50, 0x4B, 0x03, 0x04, 20, 0, 0, 0>>, 4)
+  |> should.equal("application/zip")
+}
+
+pub fn detect_with_limit_empty_bytes_test() {
+  mimetype.detect_with_limit(<<>>, 1024)
+  |> should.equal("application/octet-stream")
+}
+
+pub fn detect_with_limit_zero_test() {
+  mimetype.detect_with_limit(
+    <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>,
+    0,
+  )
+  |> should.equal("application/octet-stream")
+}
+
+pub fn detect_with_limit_negative_treated_as_zero_test() {
+  mimetype.detect_with_limit(
+    <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>,
+    -1,
+  )
+  |> should.equal("application/octet-stream")
+}
+
+pub fn detect_with_limit_default_matches_detect_test() {
+  // detect/1 must agree with detect_with_limit using the default cap on
+  // every existing fixture.
+  let png = <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>
+  let json = <<"{\"x\":1}":utf8>>
+  let text = <<"hello":utf8>>
+  mimetype.detect(png)
+  |> should.equal(mimetype.detect_with_limit(
+    png,
+    mimetype.default_detection_limit,
+  ))
+  mimetype.detect(json)
+  |> should.equal(mimetype.detect_with_limit(
+    json,
+    mimetype.default_detection_limit,
+  ))
+  mimetype.detect(text)
+  |> should.equal(mimetype.detect_with_limit(
+    text,
+    mimetype.default_detection_limit,
+  ))
+}
+
+pub fn detect_with_limit_strict_returns_ok_test() {
+  mimetype.detect_with_limit_strict(
+    <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>,
+    8,
+  )
+  |> should.equal(Ok("image/png"))
+}
+
+pub fn detect_with_limit_strict_returns_error_when_below_offset_test() {
+  let bytes = <<0:size({ 257 * 8 }), 0x75, 0x73, 0x74, 0x61, 0x72, 0:size(64)>>
+  mimetype.detect_with_limit_strict(bytes, 100)
+  |> should.equal(Error(Nil))
+}


### PR DESCRIPTION
## Summary

Expose a configurable upper bound on the number of leading bytes the
detector inspects. New public surface:

- `pub const default_detection_limit = 3072` — matches Go
  `gabriel-vasile/mimetype`'s default and comfortably covers every
  fixed-offset signature this library ships (largest today is the
  TAR `ustar` magic at offset 257).
- `pub fn detect_with_limit(bytes, limit) -> String`
- `pub fn detect_with_limit_strict(bytes, limit) -> Result(String, Nil)`

`detect`/`detect_strict` are now defined as `detect_with_limit(_,
default_detection_limit)`.

## Changes

- `src/mimetype.gleam`
  - Added the `default_detection_limit` constant with documentation.
  - Added `detect_with_limit` and `detect_with_limit_strict`. Both
    slice the input down to at most `limit` bytes (clamping to
    `[0, byte_size]`) and then run the existing magic pipeline.
  - Updated `detect` and `detect_strict` to delegate to the new
    `detect_with_limit*` functions with `default_detection_limit`.
  - Added the `truncate_to_limit` private helper using
    `bit_array.slice` and `result.unwrap` so the lint stays green
    (`thrown_away_error`).
  - Added `gleam/bit_array` and `gleam/result` to the imports.
- `test/mimetype_test.gleam`
  - Added 9 tests under `detect_with_limit_*` covering: PNG within an
    exact 8-byte limit, TAR cut off below the offset (limit 256),
    TAR found above the offset (limit 512), ZIP within a 4-byte
    limit, empty input, zero limit, negative limit clamped to zero,
    `detect/1` agreeing with `detect_with_limit(_,
    default_detection_limit)` on PNG/JSON/text fixtures, and the
    strict variant returning `Ok` and `Error(Nil)` correctly.
- `CHANGELOG.md`
  - Documented the new API surface under `## Unreleased`, calling out
    that `detect` semantics are unchanged at the default limit.

## Design Decisions

- **Default of 3072 bytes.** Matches the well-tested default from
  Go's `gabriel-vasile/mimetype`. Covers every fixed-offset signature
  this library currently ships and leaves headroom for the upcoming
  ZIP central-directory inspection (#16) and OLE CFB parsing (#21),
  both of which need to read a few KB.
- **Truncate first, then run the pipeline.** Implementing the limit
  as a slice at the public boundary keeps every internal signature
  unchanged. Each existing detector is already "no match if the
  required offsets are out of range" via `has_bytes_at`, so cutting
  the input short is sufficient to enforce the limit.
- **Negative limit treated as zero, not panic.** The issue allows
  either; choosing zero is the more forgiving behavior and matches
  what Go's `SetLimit(0)` does (returns the unknown MIME). Documented
  in the function doc comment.
- **Limits larger than the input are clamped to the input length.**
  Avoids `bit_array.slice` returning an error on out-of-range
  requests; the result is still bounded by the input itself.
- **Only `detect`/`detect_strict` get `_with_limit` variants.** The
  extension/filename helpers (`detect_with_extension*`,
  `detect_with_filename*`) defer to `detect_strict` internally, so
  callers needing limits with metadata fallbacks can either pre-slice
  the input themselves or compose `detect_with_limit_strict` with the
  extension/filename lookups manually. Adding six more variants
  (`detect_with_extension_with_limit`,
  `detect_with_extension_with_limit_strict`,
  `detect_with_filename_with_limit`,
  `detect_with_filename_with_limit_strict`, plus their strict
  counterparts) would bloat the API for marginal benefit.

## Limitations

- The internal `looks_like_json` / `looks_like_svg` / `is_all_text`
  helpers carry their own per-detector budget caps (4096 / 4096 /
  1024 bytes respectively). These caps are independent of
  `default_detection_limit`; they're still honored after truncation
  and continue to short-circuit on long inputs. A future cleanup
  could thread the public limit through to these internal budgets,
  but doing so without changing the semantics for short inputs needs
  more thought.
- The `detect_with_filename*` and `detect_with_extension*` API
  surfaces don't take a `limit` parameter (see Design Decisions).
  Callers needing both metadata fallback *and* a custom limit must
  compose the pieces themselves.

Closes #28
