### PR TITLE
feat: add MIME subtype tree with is_a / is_zip_based / ancestors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@
   (`video/x-matroska`) from WebM (`video/webm`) by inspecting the EBML
   DocType element within the first 256 bytes — a regression from the
   previous behavior where any EBML magic was reported as WebM. (#25)
+- Add a static MIME-type subtype tree and matching public predicates:
+  `is_a(mime, parent)` (reflexive + transitive), `is_zip_based`,
+  `is_xml_based`, and `ancestors`. Initial parent map covers OOXML
+  (`docx`/`xlsx`/`pptx`), OpenDocument (`odt`/`ods`/`odp`), `epub`,
+  `jar`, `apk` → `application/zip`; legacy MS Office (`doc`/`xls`/`ppt`)
+  → `application/x-ole-storage`; and `image/svg+xml` → `text/xml`.
+  Tree mirrors the design of Go's `gabriel-vasile/mimetype` (single
+  parent per child). (#26)
 - Add `detect_with_limit` and `detect_with_limit_strict` plus the
   `default_detection_limit = 3072` constant. Callers can now bound
   the number of leading bytes the detector inspects, matching the

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -13,6 +13,7 @@ import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam/string
 import mimetype/internal/db
+import mimetype/internal/hierarchy
 import mimetype/internal/magic
 
 /// Fallback MIME type used when neither metadata nor byte signatures
@@ -104,6 +105,68 @@ pub fn is_audio(mime_type: String) -> Bool {
 /// Return `True` when the MIME type's top-level media type is `video`.
 pub fn is_video(mime_type: String) -> Bool {
   string.starts_with(essence(mime_type), "video/")
+}
+
+/// Return `True` when `mime` is `parent` or transitively inherits from
+/// `parent` in the static subtype tree.
+///
+/// The relation is reflexive (`is_a(x, x)` is always `True` for any
+/// non-empty `x`) and transitive (if `a` inherits from `b` and `b`
+/// inherits from `c`, then `is_a(a, c)` is `True`).
+///
+/// Both arguments are normalized via `essence` so parameters and case
+/// differences are ignored.
+pub fn is_a(mime: String, parent: String) -> Bool {
+  let mime_essence = essence(mime)
+  let parent_essence = essence(parent)
+  use <- bool.guard(when: mime_essence == "", return: False)
+  use <- bool.guard(when: parent_essence == "", return: False)
+  is_a_loop(mime_essence, parent_essence)
+}
+
+fn is_a_loop(mime: String, parent: String) -> Bool {
+  use <- bool.lazy_guard(when: mime == parent, return: fn() { True })
+  case hierarchy.parent_of(mime) {
+    Ok(next) -> is_a_loop(next, parent)
+    Error(Nil) -> False
+  }
+}
+
+/// Return `True` when `mime` is, or inherits from, `application/zip`.
+///
+/// Convenience wrapper for `is_a(mime, "application/zip")`. Returns
+/// `True` for `.docx` / `.xlsx` / `.epub` / `.apk` and other ZIP-based
+/// container formats.
+pub fn is_zip_based(mime: String) -> Bool {
+  is_a(mime, "application/zip")
+}
+
+/// Return `True` when `mime` is, or inherits from, an XML media type.
+///
+/// Both `text/xml` and `application/xml` are accepted as XML roots, in
+/// line with RFC 7303 which permits both. Returns `True` for
+/// `image/svg+xml` and any other `*+xml` types added to the hierarchy.
+pub fn is_xml_based(mime: String) -> Bool {
+  is_a(mime, "text/xml") || is_a(mime, "application/xml")
+}
+
+/// Return the chain of ancestors of `mime`, ordered from immediate
+/// parent to root.
+///
+/// Empty input or roots return `[]`. The returned list does not include
+/// `mime` itself; use `is_a(mime, mime)` (always `True`) if you need
+/// reflexive membership.
+pub fn ancestors(mime: String) -> List(String) {
+  let mime_essence = essence(mime)
+  use <- bool.guard(when: mime_essence == "", return: [])
+  ancestors_loop(mime_essence, [])
+}
+
+fn ancestors_loop(mime: String, acc: List(String)) -> List(String) {
+  case hierarchy.parent_of(mime) {
+    Ok(parent) -> ancestors_loop(parent, [parent, ..acc])
+    Error(Nil) -> list.reverse(acc)
+  }
 }
 
 /// Look up a parameter value from a MIME type string.

--- a/src/mimetype/internal/hierarchy.gleam
+++ b/src/mimetype/internal/hierarchy.gleam
@@ -1,0 +1,62 @@
+//// Static MIME-type subtype tree.
+////
+//// Each entry is a `#(child, parent)` pair. The relation is "is-a-kind-of":
+//// for example `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
+//// is-a `application/zip` because a `.docx` file is, structurally, a ZIP
+//// archive. Lookups walk the parent chain, so a child indirectly inherits
+//// from every ancestor.
+////
+//// The tree mirrors the design of Go's `gabriel-vasile/mimetype` library:
+//// each child has at most one parent. Single-parent inheritance keeps the
+//// data shape simple and avoids ambiguity in `ancestors/1`.
+
+const parents: List(#(String, String)) = [
+  // OOXML formats — DOCX/XLSX/PPTX are ZIP archives containing XML parts.
+  #(
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/zip",
+  ),
+  #(
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/zip",
+  ),
+  #(
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/zip",
+  ),
+  // OpenDocument formats — also ZIP archives.
+  #("application/vnd.oasis.opendocument.text", "application/zip"),
+  #("application/vnd.oasis.opendocument.spreadsheet", "application/zip"),
+  #("application/vnd.oasis.opendocument.presentation", "application/zip"),
+  // ePub, JAR, APK — all ZIP underneath.
+  #("application/epub+zip", "application/zip"),
+  #("application/java-archive", "application/zip"),
+  #("application/vnd.android.package-archive", "application/zip"),
+  // Legacy MS Office formats — built on the OLE Compound File Binary
+  // structure (a.k.a. CFB / "structured storage").
+  #("application/msword", "application/x-ole-storage"),
+  #("application/vnd.ms-excel", "application/x-ole-storage"),
+  #("application/vnd.ms-powerpoint", "application/x-ole-storage"),
+  // SVG is XML.
+  #("image/svg+xml", "text/xml"),
+]
+
+/// Look up the immediate parent of `mime`, or `Error(Nil)` if `mime` is a
+/// root in the hierarchy.
+pub fn parent_of(mime: String) -> Result(String, Nil) {
+  parent_lookup(parents, mime)
+}
+
+fn parent_lookup(
+  entries: List(#(String, String)),
+  mime: String,
+) -> Result(String, Nil) {
+  case entries {
+    [] -> Error(Nil)
+    [#(child, parent), ..rest] ->
+      case child == mime {
+        True -> Ok(parent)
+        False -> parent_lookup(rest, mime)
+      }
+  }
+}

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -1126,3 +1126,110 @@ pub fn detect_with_limit_strict_returns_error_when_below_offset_test() {
   mimetype.detect_with_limit_strict(bytes, 100)
   |> should.equal(Error(Nil))
 }
+
+pub fn is_a_reflexive_test() {
+  mimetype.is_a("application/zip", "application/zip")
+  |> should.equal(True)
+}
+
+pub fn is_a_docx_inherits_from_zip_test() {
+  mimetype.is_a(
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/zip",
+  )
+  |> should.equal(True)
+}
+
+pub fn is_a_svg_inherits_from_xml_test() {
+  mimetype.is_a("image/svg+xml", "text/xml")
+  |> should.equal(True)
+}
+
+pub fn is_a_unrelated_returns_false_test() {
+  mimetype.is_a("image/png", "application/zip")
+  |> should.equal(False)
+}
+
+pub fn is_a_normalizes_essence_test() {
+  // Parameters and case differences are stripped before comparison.
+  mimetype.is_a("APPLICATION/ZIP; charset=utf-8", "application/zip")
+  |> should.equal(True)
+}
+
+pub fn is_a_empty_returns_false_test() {
+  mimetype.is_a("", "application/zip")
+  |> should.equal(False)
+  mimetype.is_a("application/zip", "")
+  |> should.equal(False)
+}
+
+pub fn is_zip_based_apk_test() {
+  mimetype.is_zip_based("application/vnd.android.package-archive")
+  |> should.equal(True)
+}
+
+pub fn is_zip_based_jar_test() {
+  mimetype.is_zip_based("application/java-archive")
+  |> should.equal(True)
+}
+
+pub fn is_zip_based_epub_test() {
+  mimetype.is_zip_based("application/epub+zip")
+  |> should.equal(True)
+}
+
+pub fn is_zip_based_zip_itself_test() {
+  mimetype.is_zip_based("application/zip")
+  |> should.equal(True)
+}
+
+pub fn is_zip_based_png_test() {
+  mimetype.is_zip_based("image/png")
+  |> should.equal(False)
+}
+
+pub fn is_xml_based_svg_test() {
+  mimetype.is_xml_based("image/svg+xml")
+  |> should.equal(True)
+}
+
+pub fn is_xml_based_text_xml_test() {
+  mimetype.is_xml_based("text/xml")
+  |> should.equal(True)
+}
+
+pub fn is_xml_based_application_xml_test() {
+  mimetype.is_xml_based("application/xml")
+  |> should.equal(True)
+}
+
+pub fn is_xml_based_html_test() {
+  // HTML is sniffable but is not XML; it is not a child of text/xml.
+  mimetype.is_xml_based("text/html")
+  |> should.equal(False)
+}
+
+pub fn ancestors_epub_test() {
+  mimetype.ancestors("application/epub+zip")
+  |> should.equal(["application/zip"])
+}
+
+pub fn ancestors_root_returns_empty_test() {
+  mimetype.ancestors("application/octet-stream")
+  |> should.equal([])
+}
+
+pub fn ancestors_unknown_mime_returns_empty_test() {
+  mimetype.ancestors("application/x-not-real")
+  |> should.equal([])
+}
+
+pub fn ancestors_msword_inherits_from_ole_test() {
+  mimetype.ancestors("application/msword")
+  |> should.equal(["application/x-ole-storage"])
+}
+
+pub fn ancestors_empty_input_returns_empty_test() {
+  mimetype.ancestors("")
+  |> should.equal([])
+}


### PR DESCRIPTION
## Summary

Add a static MIME-type subtype tree and matching public predicates so
callers can ask "is this MIME type a kind of ZIP?" or "does this
inherit from XML?" without hardcoding strings on the consumer side. The
tree mirrors Go `gabriel-vasile/mimetype`'s design: each child has at
most one parent, lookups walk the parent chain, and the relation is
reflexive (any non-empty MIME type is a kind of itself).

## Changes

- `src/mimetype/internal/hierarchy.gleam` (new)
  - Static `parents: List(#(String, String))` mapping each child MIME
    type to its single parent. Initial entries:
    - OOXML: `docx` / `xlsx` / `pptx` → `application/zip`
    - OpenDocument: `odt` / `ods` / `odp` → `application/zip`
    - `epub` / `jar` / `apk` → `application/zip`
    - Legacy MS Office: `doc` / `xls` / `ppt` → `application/x-ole-storage`
    - `image/svg+xml` → `text/xml`
  - `parent_of(mime: String) -> Result(String, Nil)` for the immediate
    parent lookup.
- `src/mimetype.gleam`
  - Added 4 public functions:
    - `is_a(mime, parent) -> Bool` — reflexive + transitive subtype
      check, normalizes both arguments through `essence` so parameters
      and case differences are stripped.
    - `is_zip_based(mime) -> Bool` — convenience for
      `is_a(mime, "application/zip")`.
    - `is_xml_based(mime) -> Bool` — `is_a(mime, "text/xml")` OR
      `is_a(mime, "application/xml")`, since RFC 7303 permits both
      XML roots.
    - `ancestors(mime) -> List(String)` — chain of ancestors from
      immediate parent to root, excluding `mime` itself.
  - Imported `mimetype/internal/hierarchy` alongside the existing
    `db` and `magic` imports.
- `test/mimetype_test.gleam`
  - Added 19 new tests under `is_a_*`, `is_zip_based_*`,
    `is_xml_based_*`, and `ancestors_*`. Coverage includes:
    reflexivity, transitivity (DOCX → ZIP, MSWORD → OLE, SVG → XML),
    unrelated rejection (PNG ≠ ZIP, HTML ≠ XML), essence
    normalization (uppercase + parameters), empty-input handling,
    root types returning `[]` from `ancestors`, and the `is_xml_based`
    fallback for `application/xml`.
- `CHANGELOG.md`
  - Documented the new public surface under `## Unreleased`.

## Design Decisions

- **Single-parent tree, not a DAG.** Each MIME type has at most one
  parent. This mirrors the design that Go `gabriel-vasile/mimetype`
  has used in production for years, keeps `ancestors/1` unambiguous,
  and avoids the cyclic-graph hazards of multi-inheritance. If a
  format like DOCX wants to be both "a ZIP archive" and "an XML
  bundle", we model the dominant container relationship (ZIP) and
  leave the XML aspect to per-part inspection.
- **Reflexive relation.** `is_a(x, x)` returns `True` for any
  non-empty `x`, even when `x` is not a child in the parent map.
  This matches how Go expresses `mtype.Is(mtype.String())` — every
  type is, trivially, a kind of itself. Rejected callers (e.g.
  empty strings) explicitly fall through to `False`.
- **`is_xml_based` checks both `text/xml` and `application/xml`.** RFC
  7303 declares both as valid XML media types, with WHATWG returning
  `text/xml` and many Linux tools returning `application/xml`. The
  predicate is a disjunction so callers don't have to remember which
  variant the library emits.
- **Hierarchy lives in its own internal module.** Keeping
  `internal/hierarchy.gleam` separate from the magic detector keeps
  the static-data concern out of the per-byte detection path. The
  detector module already grew large; piling another `const` block
  on top would make it harder to navigate.
- **`essence` normalization at the API boundary.** Both arguments to
  `is_a` go through `essence` (lowercase, strip parameters, trim).
  This matches the existing `is_image` / `is_text` helpers and keeps
  the static map case-canonical.
- **Reused `bool.guard` and `bool.lazy_guard` patterns.** The
  hierarchy walks use the same flat-control-flow style as the rest
  of the codebase, satisfying glinter's `prefer_guard_clause`
  without nested `case True/False` arms.

## Limitations

- The hierarchy tree is **static**, not derived from detection. A
  caller who sniffs `application/zip` from a `.docx` file gets back
  `application/zip`; classifying that as DOCX requires the upcoming
  ZIP-container introspection (#16) so we read the embedded
  `[Content_Types].xml`. Once #16 lands, the hierarchy lets a caller
  ask `is_zip_based(detected_mime)` to handle the union of plain
  ZIPs and ZIP-derived formats uniformly.
- The current map is a **starter set**. Adding parents for, say,
  `application/x-www-form-urlencoded` (text-derived), GLB (binary
  glTF), or Matroska variants is just a one-line addition to
  `internal/hierarchy.gleam` — no API changes needed.
- `ancestors/1` does not include `mime` itself. Use `is_a(mime, mime)`
  if you need reflexive membership instead of strict ancestry.

Closes #26
