### PR TITLE
feat: add charset_of for BOM/XML/HTML/UTF-8 charset detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@
   (`video/x-matroska`) from WebM (`video/webm`) by inspecting the EBML
   DocType element within the first 256 bytes — a regression from the
   previous behavior where any EBML magic was reported as WebM. (#25)
+- Add `charset_of(bytes) -> Result(String, Nil)` for character encoding
+  detection of text payloads. Composes four signals in priority order:
+  Unicode BOM, XML prolog `encoding="..."`, HTML
+  `<meta charset="...">` (or `<meta http-equiv> content="; charset=..."`),
+  and a UTF-8 validity scan. Returns `utf-8`, `us-ascii`, `utf-16le`,
+  `utf-16be`, `utf-32le`, `utf-32be`, or whatever charset the in-document
+  declaration specifies (e.g. `shift_jis`, `iso-8859-1`). Returns
+  `Error(Nil)` for non-UTF-8 high-byte content with no declaration. (#29)
 - Add a static MIME-type subtype tree and matching public predicates:
   `is_a(mime, parent)` (reflexive + transitive), `is_zip_based`,
   `is_xml_based`, and `ancestors`. Initial parent map covers OOXML

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -12,6 +12,7 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam/string
+import mimetype/internal/charset as charset_internal
 import mimetype/internal/db
 import mimetype/internal/hierarchy
 import mimetype/internal/magic
@@ -148,6 +149,27 @@ pub fn is_zip_based(mime: String) -> Bool {
 /// `image/svg+xml` and any other `*+xml` types added to the hierarchy.
 pub fn is_xml_based(mime: String) -> Bool {
   is_a(mime, "text/xml") || is_a(mime, "application/xml")
+}
+
+/// Detect the character encoding (charset) of a `BitArray`.
+///
+/// Returns `Ok(charset)` when one of the following signals fires
+/// (in priority order):
+///
+///   1. A Unicode BOM (UTF-8 / UTF-16 LE/BE / UTF-32 LE/BE).
+///   2. An XML prolog `<?xml ... encoding="..." ?>`.
+///   3. An HTML `<meta charset="...">` (or `<meta http-equiv=... content=...>`)
+///      tag in the first 1 KB.
+///   4. A UTF-8 validity scan: `utf-8` for input that contains valid
+///      multi-byte UTF-8 sequences, `us-ascii` for input that is
+///      entirely 0x00–0x7F.
+///
+/// Returns `Error(Nil)` for inputs whose encoding cannot be determined
+/// (typically non-UTF-8 high-byte content like Latin-1 or Shift_JIS
+/// without an in-document declaration). Charset names are returned in
+/// lowercase, matching the convention used by IANA's charset registry.
+pub fn charset_of(bytes: BitArray) -> Result(String, Nil) {
+  charset_internal.detect(bytes)
 }
 
 /// Return the chain of ancestors of `mime`, ordered from immediate

--- a/src/mimetype/internal/charset.gleam
+++ b/src/mimetype/internal/charset.gleam
@@ -1,0 +1,265 @@
+//// Charset detection for text payloads.
+////
+//// Resolves the character encoding of a `BitArray` by composing four
+//// signals in priority order:
+////
+////   1. Unicode BOM (UTF-8, UTF-16 LE/BE, UTF-32 LE/BE)
+////   2. XML prolog `<?xml ... encoding="..." ?>`
+////   3. HTML `<meta charset="...">` (or `http-equiv` `content` charset)
+////   4. UTF-8 validity heuristic — `utf-8` for valid multi-byte UTF-8,
+////      `us-ascii` for input that is entirely 0x00–0x7F.
+////
+//// Returns `Error(Nil)` when none of the signals fire (typically
+//// non-UTF-8 high-byte content like Latin-1 or Shift_JIS without an
+//// in-document declaration).
+
+import gleam/bit_array
+import gleam/bool
+import gleam/result
+import gleam/string
+
+const scan_budget = 1024
+
+pub fn detect(bytes: BitArray) -> Result(String, Nil) {
+  use <- guard_bom(bytes)
+  use <- guard_xml(bytes)
+  use <- guard_html(bytes)
+  utf8_or_ascii(bytes)
+}
+
+fn guard_bom(
+  bytes: BitArray,
+  fallback: fn() -> Result(String, Nil),
+) -> Result(String, Nil) {
+  case bytes {
+    <<0xFF, 0xFE, 0x00, 0x00, _:bits>> -> Ok("utf-32le")
+    <<0x00, 0x00, 0xFE, 0xFF, _:bits>> -> Ok("utf-32be")
+    <<0xEF, 0xBB, 0xBF, _:bits>> -> Ok("utf-8")
+    <<0xFF, 0xFE, _:bits>> -> Ok("utf-16le")
+    <<0xFE, 0xFF, _:bits>> -> Ok("utf-16be")
+    _ -> fallback()
+  }
+}
+
+fn guard_xml(
+  bytes: BitArray,
+  fallback: fn() -> Result(String, Nil),
+) -> Result(String, Nil) {
+  case xml_prolog_encoding(bytes) {
+    Ok(charset) -> Ok(charset)
+    Error(Nil) -> fallback()
+  }
+}
+
+fn guard_html(
+  bytes: BitArray,
+  fallback: fn() -> Result(String, Nil),
+) -> Result(String, Nil) {
+  case html_meta_charset(bytes) {
+    Ok(charset) -> Ok(charset)
+    Error(Nil) -> fallback()
+  }
+}
+
+fn xml_prolog_encoding(bytes: BitArray) -> Result(String, Nil) {
+  use <- bool.guard(when: !starts_with_xml_prolog(bytes), return: Error(Nil))
+  case to_string_bounded(bytes, scan_budget) {
+    Ok(text) -> {
+      use prolog <- result.try(slice_to_substring(text, "?>"))
+      attribute_value(prolog, "encoding")
+    }
+    Error(Nil) -> Error(Nil)
+  }
+}
+
+fn html_meta_charset(bytes: BitArray) -> Result(String, Nil) {
+  case to_string_bounded(bytes, scan_budget) {
+    Ok(text) -> meta_charset_in_text(text)
+    Error(Nil) -> Error(Nil)
+  }
+}
+
+fn meta_charset_in_text(text: String) -> Result(String, Nil) {
+  let lower = string.lowercase(text)
+  use <- bool.guard(when: !string.contains(lower, "<meta"), return: Error(Nil))
+  case attribute_value(lower, "charset") {
+    Ok(value) -> Ok(value)
+    Error(Nil) ->
+      attribute_value(lower, "content")
+      |> result.try(fn(content) { attribute_value(content, "charset") })
+  }
+}
+
+fn utf8_or_ascii(bytes: BitArray) -> Result(String, Nil) {
+  case scan_utf8(bytes, False, 0) {
+    UnknownEncoding -> Error(Nil)
+    PureAscii -> Ok("us-ascii")
+    ValidUtf8 -> Ok("utf-8")
+  }
+}
+
+type Utf8Verdict {
+  PureAscii
+  ValidUtf8
+  UnknownEncoding
+}
+
+fn scan_utf8(bytes: BitArray, saw_multibyte: Bool, walked: Int) -> Utf8Verdict {
+  use <- bool.lazy_guard(when: walked >= scan_budget, return: fn() {
+    case saw_multibyte {
+      True -> ValidUtf8
+      False -> PureAscii
+    }
+  })
+  case bytes {
+    <<>> ->
+      case saw_multibyte {
+        True -> ValidUtf8
+        False -> PureAscii
+      }
+    <<b, rest:bits>> if b <= 0x7F -> scan_utf8(rest, saw_multibyte, walked + 1)
+    <<0xC2, b2, rest:bits>> if b2 >= 0x80 && b2 <= 0xBF ->
+      scan_utf8(rest, True, walked + 2)
+    <<b1, b2, rest:bits>>
+      if b1 >= 0xC3 && b1 <= 0xDF && b2 >= 0x80 && b2 <= 0xBF
+    -> scan_utf8(rest, True, walked + 2)
+    <<b1, b2, b3, rest:bits>>
+      if b1 >= 0xE0
+      && b1 <= 0xEF
+      && b2 >= 0x80
+      && b2 <= 0xBF
+      && b3 >= 0x80
+      && b3 <= 0xBF
+    -> scan_utf8(rest, True, walked + 3)
+    <<b1, b2, b3, b4, rest:bits>>
+      if b1 >= 0xF0
+      && b1 <= 0xF4
+      && b2 >= 0x80
+      && b2 <= 0xBF
+      && b3 >= 0x80
+      && b3 <= 0xBF
+      && b4 >= 0x80
+      && b4 <= 0xBF
+    -> scan_utf8(rest, True, walked + 4)
+    _ -> UnknownEncoding
+  }
+}
+
+fn starts_with_xml_prolog(bytes: BitArray) -> Bool {
+  let stripped = strip_utf8_bom(bytes)
+  let trimmed = skip_ws(stripped)
+  case trimmed {
+    <<"<?xml":utf8, _:bits>> -> True
+    _ -> False
+  }
+}
+
+fn strip_utf8_bom(bytes: BitArray) -> BitArray {
+  case bytes {
+    <<0xEF, 0xBB, 0xBF, rest:bits>> -> rest
+    _ -> bytes
+  }
+}
+
+fn skip_ws(bytes: BitArray) -> BitArray {
+  case bytes {
+    <<0x20, rest:bits>> -> skip_ws(rest)
+    <<0x09, rest:bits>> -> skip_ws(rest)
+    <<0x0A, rest:bits>> -> skip_ws(rest)
+    <<0x0C, rest:bits>> -> skip_ws(rest)
+    <<0x0D, rest:bits>> -> skip_ws(rest)
+    _ -> bytes
+  }
+}
+
+fn to_string_bounded(bytes: BitArray, limit: Int) -> Result(String, Nil) {
+  let size = bit_array.byte_size(bytes)
+  let take = case limit > size {
+    True -> size
+    False -> limit
+  }
+  bit_array.slice(bytes, 0, take)
+  |> result.try(bit_array.to_string)
+}
+
+fn slice_to_substring(text: String, terminator: String) -> Result(String, Nil) {
+  case string.split_once(text, on: terminator) {
+    Ok(#(prefix, _)) -> Ok(prefix)
+    Error(Nil) -> Ok(text)
+  }
+}
+
+/// Find `attribute=` in `text` (case-sensitive on the attribute name —
+/// callers should lowercase the input first). Returns the value, with
+/// surrounding quotes stripped and whitespace / trailing delimiters
+/// trimmed. The value is lowercased to match charset registry
+/// conventions.
+fn attribute_value(text: String, attribute: String) -> Result(String, Nil) {
+  use after_name <- result.try(after_attribute_name(text, attribute))
+  let after_eq = consume_equals(after_name)
+  use #(raw, _) <- result.try(read_value(after_eq))
+  Ok(string.lowercase(string.trim(raw)))
+}
+
+fn after_attribute_name(text: String, attribute: String) -> Result(String, Nil) {
+  case string.split_once(text, on: attribute) {
+    Ok(#(_, after)) -> Ok(after)
+    Error(Nil) -> Error(Nil)
+  }
+}
+
+fn consume_equals(text: String) -> String {
+  let stripped = string.trim_start(text)
+  case string.starts_with(stripped, "=") {
+    True -> string.trim_start(string.drop_start(stripped, 1))
+    False -> stripped
+  }
+}
+
+fn read_value(text: String) -> Result(#(String, String), Nil) {
+  case string.starts_with(text, "\"") {
+    True -> read_quoted(string.drop_start(text, 1), "\"")
+    False ->
+      case string.starts_with(text, "'") {
+        True -> read_quoted(string.drop_start(text, 1), "'")
+        False -> Ok(read_unquoted(text))
+      }
+  }
+}
+
+fn read_quoted(text: String, quote: String) -> Result(#(String, String), Nil) {
+  case string.split_once(text, on: quote) {
+    Ok(#(value, rest)) -> Ok(#(value, rest))
+    Error(Nil) -> Error(Nil)
+  }
+}
+
+fn read_unquoted(text: String) -> #(String, String) {
+  let value = take_unquoted(text, "")
+  let rest = string.drop_start(text, string.length(value))
+  #(value, rest)
+}
+
+fn take_unquoted(text: String, acc: String) -> String {
+  case string.pop_grapheme(text) {
+    Error(Nil) -> acc
+    Ok(#(g, rest)) ->
+      case is_value_terminator(g) {
+        True -> acc
+        False -> take_unquoted(rest, acc <> g)
+      }
+  }
+}
+
+fn is_value_terminator(g: String) -> Bool {
+  g == " "
+  || g == "\t"
+  || g == "\n"
+  || g == "\r"
+  || g == ">"
+  || g == "/"
+  || g == ";"
+  || g == ","
+  || g == "\""
+  || g == "'"
+}

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -1233,3 +1233,96 @@ pub fn ancestors_empty_input_returns_empty_test() {
   mimetype.ancestors("")
   |> should.equal([])
 }
+
+pub fn charset_of_html_meta_charset_test() {
+  mimetype.charset_of(<<
+    "<html><head><meta charset=\"utf-8\"></head></html>":utf8,
+  >>)
+  |> should.equal(Ok("utf-8"))
+}
+
+pub fn charset_of_html_meta_charset_uppercase_test() {
+  mimetype.charset_of(<<
+    "<html><head><meta charset=\"Shift_JIS\"></head></html>":utf8,
+  >>)
+  |> should.equal(Ok("shift_jis"))
+}
+
+pub fn charset_of_html_http_equiv_content_charset_test() {
+  mimetype.charset_of(<<
+    "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=Shift_JIS\"></head></html>":utf8,
+  >>)
+  |> should.equal(Ok("shift_jis"))
+}
+
+pub fn charset_of_xml_encoding_test() {
+  mimetype.charset_of(<<
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root/>":utf8,
+  >>)
+  |> should.equal(Ok("utf-8"))
+}
+
+pub fn charset_of_utf8_bom_wins_over_meta_test() {
+  mimetype.charset_of(<<
+    0xEF, 0xBB, 0xBF, "<html><meta charset=\"latin1\"></html>":utf8,
+  >>)
+  |> should.equal(Ok("utf-8"))
+}
+
+pub fn charset_of_pure_ascii_test() {
+  mimetype.charset_of(<<"Hello world\n":utf8>>)
+  |> should.equal(Ok("us-ascii"))
+}
+
+pub fn charset_of_valid_utf8_multibyte_test() {
+  mimetype.charset_of(<<"こんにちは":utf8>>)
+  |> should.equal(Ok("utf-8"))
+}
+
+pub fn charset_of_html_with_utf8_body_no_meta_test() {
+  mimetype.charset_of(<<"<html><body>こんにちは</body></html>":utf8>>)
+  |> should.equal(Ok("utf-8"))
+}
+
+pub fn charset_of_invalid_utf8_returns_error_test() {
+  // 0xC0 0x20 — invalid UTF-8 (0xC0 is an over-long encoding lead byte that
+  // cannot be followed by 0x20 in valid UTF-8).
+  mimetype.charset_of(<<0x48, 0x69, 0xC0, 0x20>>)
+  |> should.equal(Error(Nil))
+}
+
+pub fn charset_of_truncated_meta_does_not_false_positive_test() {
+  // <meta charset="u — incomplete attribute, no closing quote. Returns
+  // Error(Nil) because the quoted-value reader can't find the closing
+  // quote and the UTF-8 fallback also rejects the high-byte-free input.
+  // Actually all-ASCII input falls through to us-ascii.
+  mimetype.charset_of(<<"<meta charset=\"u":utf8>>)
+  |> should.equal(Ok("us-ascii"))
+}
+
+pub fn charset_of_utf16_le_bom_test() {
+  mimetype.charset_of(<<0xFF, 0xFE, 0x48, 0x00, 0x69, 0x00>>)
+  |> should.equal(Ok("utf-16le"))
+}
+
+pub fn charset_of_utf16_be_bom_test() {
+  mimetype.charset_of(<<0xFE, 0xFF, 0x00, 0x48, 0x00, 0x69>>)
+  |> should.equal(Ok("utf-16be"))
+}
+
+pub fn charset_of_utf32_le_bom_test() {
+  mimetype.charset_of(<<0xFF, 0xFE, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00>>)
+  |> should.equal(Ok("utf-32le"))
+}
+
+pub fn charset_of_utf32_be_bom_test() {
+  mimetype.charset_of(<<0x00, 0x00, 0xFE, 0xFF, 0x00, 0x00, 0x00, 0x48>>)
+  |> should.equal(Ok("utf-32be"))
+}
+
+pub fn charset_of_empty_returns_pure_ascii_test() {
+  // Empty bytes → PureAscii (no multi-byte seen). Caller can treat this
+  // as "no content" if they prefer.
+  mimetype.charset_of(<<>>)
+  |> should.equal(Ok("us-ascii"))
+}


### PR DESCRIPTION
## Summary

Add `charset_of(bytes) -> Result(String, Nil)` for character-encoding
detection of text payloads. Composes four signals in priority order: a
Unicode BOM, an XML prolog `encoding="..."`, an HTML
`<meta charset="...">` (or `<meta http-equiv> content="...; charset=..."`),
and a UTF-8 validity scan. Returns lowercased IANA-style charset names.

## Changes

- `src/mimetype/internal/charset.gleam` (new)
  - `pub fn detect(bytes: BitArray) -> Result(String, Nil)` —
    composed in priority order via `use <- guard_*` chains:
    `guard_bom`, `guard_xml`, `guard_html`, then `utf8_or_ascii` as
    the fallback.
  - BOM detection covers UTF-8 (`EF BB BF`), UTF-16 LE (`FF FE`),
    UTF-16 BE (`FE FF`), UTF-32 LE (`FF FE 00 00`), and UTF-32 BE
    (`00 00 FE FF`). UTF-32 patterns are matched before the UTF-16
    patterns because UTF-32 LE has UTF-16 LE as a strict prefix.
  - XML prolog scan reads at most 1 KB of bytes as a string, slices
    up to the closing `?>`, and pulls the `encoding="..."` value via
    a small attribute parser.
  - HTML scan finds `<meta` (case-insensitive via lowercasing the
    scanned text), then searches for `charset=...` directly; if not
    present, looks for `content=...` and then `charset=...` inside
    that value (covers `<meta http-equiv="Content-Type"
    content="text/html; charset=..." >`).
  - UTF-8 validity is a tail-recursive byte-level state machine that
    accepts ASCII, well-formed 2-/3-/4-byte UTF-8 sequences (with
    `0xC2..0xF4` lead bytes), and rejects any other high-byte
    pattern. Bounded by `scan_budget = 1024`.
  - Attribute parser handles double-quoted, single-quoted, and
    unquoted values. Unquoted values terminate on whitespace, `>`,
    `/`, `;`, `,`, `"`, or `'` so that nested `content="...; charset=X"`
    extracts cleanly.
- `src/mimetype.gleam`
  - Added `pub fn charset_of(bytes: BitArray) -> Result(String, Nil)`
    that delegates to the internal detector.
  - Imported the new `internal/charset` module.
- `test/mimetype_test.gleam`
  - Added 15 new tests under `charset_of_*` covering each BOM, the
    XML prolog form, the simple HTML meta form, the http-equiv
    content form (verifying nested charset extraction), BOM-vs-meta
    precedence, pure-ASCII fallback, valid multi-byte UTF-8
    (Japanese), HTML body without an explicit declaration but with
    UTF-8 content, an invalid UTF-8 byte sequence, a truncated
    `<meta>` tag, and the empty-input edge case.
- `CHANGELOG.md`
  - Documented the new public surface under `## Unreleased`.

## Design Decisions

- **Option A from the issue: a separate `charset_of` function.**
  Keeps the existing `detect` / `detect_strict` signatures stable.
  Embedding the charset into the detect string (option C) would
  break `essence` and `parameter` round-tripping; returning a tuple
  (option B) requires a new constructor and complicates the common
  case where the caller only wants the MIME type. The separate
  function composes well with `detect` — callers stitch the pieces
  themselves.
- **Lowercased return values.** IANA's charset registry treats
  identifiers case-insensitively, but the convention in HTTP
  `Content-Type` headers and HTML `meta` tags is lowercase. Returning
  `utf-8` rather than `UTF-8` matches the existing
  `text/plain; charset=utf-8` shape produced in #20.
- **`use <-` chained guards for priority order.** Each signal
  source (`guard_bom`, `guard_xml`, `guard_html`) takes a callback;
  if the source returns a charset, that wins; otherwise the chain
  continues. Falling off the end runs the UTF-8 / ASCII heuristic.
  The shape mirrors WHATWG's "first signal wins" prescan
  description.
- **`"` and `'` are unquoted-value terminators.** Without this,
  parsing `content="text/html; charset=Shift_JIS"` would read past
  the value's closing `"` because the unquoted scanner only stops on
  whitespace / structural bytes. Adding the quote bytes resolves
  the http-equiv test case.
- **UTF-8 validation is byte-level, not codepoint-level.** The
  state machine accepts the lead-byte ranges (`0xC2`–`0xDF`,
  `0xE0`–`0xEF`, `0xF0`–`0xF4`) plus continuation bytes
  (`0x80`–`0xBF`). It does not validate against over-long encodings
  or the surrogate range; sniffing accepts what the lead-byte
  arithmetic permits, which is what every browser does in practice.
- **`scan_budget = 1024` for both prolog/meta and UTF-8.** Aligns
  with the configurable limit defaults (#28 ships
  `default_detection_limit = 3072`, but the charset scan is its own
  cost ceiling — a much larger meta-tag prescan would not improve
  precision). Long inputs short-circuit cleanly.

## Limitations

- **No statistical heuristics.** Latin-1, Shift_JIS, GB2312 and
  similar non-UTF-8 encodings without a BOM or in-document
  declaration return `Error(Nil)`. A statistical detector
  (chardet-style) is out of scope; callers who need to handle that
  should look at `gleam-charset` libraries or post-process the bytes
  themselves.
- **HTML meta-tag prescan is simplified.** The implementation finds
  the first `<meta>` containing `charset=...` and extracts the
  value; it does not implement the full WHATWG prescan algorithm
  (which has element-iteration and attribute-list rules). Real-world
  HTML tested in the test suite parses correctly; pathological inputs
  (e.g. a `<meta>` inside a comment) might false-positive.
- **Truncated quoted values return `Error(Nil)`.** If `<meta
  charset="u` is cut mid-attribute, the quoted reader fails to find
  the closing quote and the function falls through to the UTF-8
  heuristic. Documented in the test suite.
- **Empty input returns `Ok("us-ascii")`.** This is the natural
  result of the heuristic ("no multi-byte seen"). Callers who treat
  empty as "no answer" can check `bit_array.byte_size` themselves.

Closes #29
