### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.2.0] - 2026-04-26
+
 - Detect `application/json` from leading bytes via a bounded JSON-prefix
   validator. Top-level objects (`{...}`) and arrays (`[...]`) are recognized
   after optional UTF-8 BOM and whitespace, including truncated inputs.

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "mimetype"
-version = "0.1.0"
+version = "0.2.0"
 description = "MIME type lookup and magic-number detection for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "mimetype" }


### PR DESCRIPTION
- Detect `application/json` from leading bytes via a bounded JSON-prefix
  validator. Top-level objects (`{...}`) and arrays (`[...]`) are recognized
  after optional UTF-8 BOM and whitespace, including truncated inputs.
  Bare top-level scalars (numbers, strings, `true`/`false`/`null`) are
  intentionally not sniffed to avoid false positives on plain text. (#19)
- Detect `text/html` from leading bytes by case-insensitive matching on a
  WHATWG-aligned tag list (`<!doctype html`, `<html`, `<head`, `<body`,
  `<script`, `<iframe`, `<table`, `<style`, `<title`, `<br`, `<p`, `<h1`,
  `<div`, `<font`, `<img`, `<a`) followed by a tag-terminating byte
  (whitespace, `>`, or end of input). (#17)
- Detect `text/xml` from leading bytes by recognizing the lowercase
  `<?xml` declaration followed by a tag-terminating byte. Both detectors
  strip an optional UTF-8 BOM and HTML whitespace before matching. (#17)
- Detect `image/svg+xml` from the XML root element. The detector skips an
  optional UTF-8 BOM, whitespace, an `<?xml ... ?>` prolog, an
  `<!DOCTYPE ...>` declaration, and any number of `<!-- ... -->` comments
  before checking for a case-sensitive `<svg` element followed by a tag
  terminator. (#18)
- Detect six font formats: TrueType (`font/ttf`), OpenType (`font/otf`),
  TrueType Collection (`font/collection`), WOFF (`font/woff`), WOFF2
  (`font/woff2`), and EOT (`application/vnd.ms-fontobject`). MIME types
  follow RFC 8081. (#22)
- Detect nine additional image formats: Photoshop
  (`image/vnd.adobe.photoshop`), JPEG 2000 (`image/jp2`), JPEG XL raw
  codestream and ISO BMFF container (both `image/jxl`), DDS
  (`image/vnd.ms-dds`), Radiance HDR (`image/vnd.radiance`), OpenEXR
  (`image/x-exr`), QOI (`image/x-qoi`), and FITS (`image/fits`). (#23)
- Detect eight additional compression / archive formats: LZ4 frame and
  legacy (`application/x-lz4`), lzip (`application/x-lzip`), Snappy
  framed (`application/x-snappy-framed`), `.Z` compress
  (`application/x-compress`), ar archive (`application/x-archive`),
  LZH/LHA (`application/x-lzh-compressed`), and zlib raw streams
  (`application/x-deflate`). (#24)
- Detect additional audio/video formats: ASF / WMV / WMA
  (`application/vnd.ms-asf`), Flash Video (`video/x-flv`), AAC ADTS and
  ADIF (both `audio/aac`), AMR (`audio/amr`), AMR-WB (`audio/amr-wb`),
  and AC3 (`audio/ac3`). Differentiate Matroska (`video/x-matroska`)
  from WebM (`video/webm`) by inspecting the EBML DocType element. (#25)
- Add `charset_of(bytes) -> Result(String, Nil)` for character encoding
  detection of text payloads. Composes BOM, XML prolog encoding, HTML
  `<meta charset>`, and a UTF-8 validity scan in priority order. (#29)
- Add a static MIME-type subtype tree and matching public predicates:
  `is_a`, `is_zip_based`, `is_xml_based`, and `ancestors`. (#26)
- Add `detect_with_limit` and `detect_with_limit_strict` plus the
  `default_detection_limit = 3072` constant for bounding the number of
  leading bytes the detector inspects, matching Go's `SetLimit` knob. (#28)
- Detect plain text as a final fallback. Inputs prefixed with a Unicode
  BOM are reported with the explicit charset (`text/plain; charset=...`).
  Inputs without a BOM that are entirely printable ASCII or HTML
  whitespace within the first 1 KB are reported as `text/plain`.
  **Behavior change**: ASCII-only inputs that previously fell back to
  `application/octet-stream` (config files, CSVs without extension,
  near-miss HTML fragments) are now reported as `text/plain`. (#20)

### Behavior changes

- WebM detection now requires the EBML `DocType="webm"` element within
  the first 256 bytes. Plain EBML magic without a DocType (which used
  to be reported as `video/webm`) now falls back to
  `application/octet-stream`. (#25)
- ASCII-only inputs that previously fell back to `application/octet-stream`
  are now reported as `text/plain`. (#20)
