### PR TITLE
feat: add reader-based detection API for streaming inputs

### DIFF
--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -307,6 +307,42 @@ fn truncate_to_limit(bytes: BitArray, limit: Int) -> BitArray {
   bit_array.slice(bytes, 0, safe_limit) |> result.unwrap(<<>>)
 }
 
+/// A callback that reads up to the requested number of bytes from an
+/// input source. Returns `Ok(bits)` with the bytes actually read, or
+/// `Error(reason)` if the read fails. A reader that returns fewer bytes
+/// than requested signals end-of-input.
+pub type Reader =
+  fn(Int) -> Result(BitArray, String)
+
+/// Detect a MIME type by pulling at most `limit` leading bytes through
+/// a caller-supplied reader.
+///
+/// The reader is called once with `limit` as the requested byte count.
+/// If the reader returns an error, the default MIME type is returned.
+pub fn detect_reader(read: Reader, limit: Int) -> String {
+  case detect_reader_strict(read, limit) {
+    Ok(mime_type) -> mime_type
+    Error(Nil) -> default_mime_type
+  }
+}
+
+/// Detect a MIME type by pulling at most `limit` leading bytes through
+/// a caller-supplied reader.
+///
+/// This strict variant returns `Error(Nil)` when the reader fails or
+/// when no supported magic-number signature matches within the bytes
+/// returned.
+pub fn detect_reader_strict(read: Reader, limit: Int) -> Result(String, Nil) {
+  let safe_limit = case limit < 1 {
+    True -> 0
+    False -> limit
+  }
+  case read(safe_limit) {
+    Ok(bytes) -> detect_with_limit_strict(bytes, safe_limit)
+    Error(_) -> Error(Nil)
+  }
+}
+
 /// Detect a MIME type from bytes, falling back to an explicit
 /// extension when the content signature is unknown.
 ///

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -1127,6 +1127,67 @@ pub fn detect_with_limit_strict_returns_error_when_below_offset_test() {
   |> should.equal(Error(Nil))
 }
 
+pub fn detect_reader_returns_same_as_detect_test() {
+  let png = <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>
+  let reader = fn(_limit) { Ok(png) }
+  mimetype.detect_reader(reader, 3072)
+  |> should.equal("image/png")
+}
+
+pub fn detect_reader_truncated_prefix_falls_back_test() {
+  // TAR signature at offset 257 — only 64 bytes provided
+  let short_bytes = <<0:size({ 64 * 8 })>>
+  let reader = fn(_limit) { Ok(short_bytes) }
+  mimetype.detect_reader(reader, 3072)
+  |> should.equal("application/octet-stream")
+}
+
+pub fn detect_reader_short_eof_still_detects_test() {
+  // Reader returns fewer bytes than limit but contains a valid PNG signature
+  let png = <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>
+  let reader = fn(_limit) { Ok(png) }
+  mimetype.detect_reader(reader, 8192)
+  |> should.equal("image/png")
+}
+
+pub fn detect_reader_strict_error_returns_error_nil_test() {
+  let reader = fn(_limit) { Error("disk read failure") }
+  mimetype.detect_reader_strict(reader, 3072)
+  |> should.equal(Error(Nil))
+}
+
+pub fn detect_reader_error_returns_default_test() {
+  let reader = fn(_limit) { Error("io error") }
+  mimetype.detect_reader(reader, 3072)
+  |> should.equal("application/octet-stream")
+}
+
+pub fn detect_reader_called_with_limit_test() {
+  // Verify reader receives the limit value
+  let reader = fn(requested) {
+    case requested {
+      100 -> Ok(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>)
+      _ -> Error("unexpected limit")
+    }
+  }
+  mimetype.detect_reader(reader, 100)
+  |> should.equal("image/png")
+}
+
+pub fn detect_reader_strict_ok_test() {
+  let png = <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>
+  let reader = fn(_limit) { Ok(png) }
+  mimetype.detect_reader_strict(reader, 3072)
+  |> should.equal(Ok("image/png"))
+}
+
+pub fn detect_reader_strict_no_match_returns_error_test() {
+  let unknown = <<0x00, 0x01, 0x02, 0x03>>
+  let reader = fn(_limit) { Ok(unknown) }
+  mimetype.detect_reader_strict(reader, 3072)
+  |> should.equal(Error(Nil))
+}
+
 pub fn is_a_reflexive_test() {
   mimetype.is_a("application/zip", "application/zip")
   |> should.equal(True)


### PR DESCRIPTION
## Summary

Add `detect_reader` and `detect_reader_strict` functions that accept a caller-supplied `Reader` callback to pull bytes on demand, enabling MIME detection without loading entire files into memory.

## Changes

- Add `Reader` public type alias: `fn(Int) -> Result(BitArray, String)`
- Add `detect_reader(read: Reader, limit: Int) -> String` — calls reader once with limit, falls back to default on error or no match
- Add `detect_reader_strict(read: Reader, limit: Int) -> Result(String, Nil)` — strict variant returning `Error(Nil)`
- Add 8 test cases covering: normal detection, truncated prefix fallback, short EOF, reader error handling, limit passthrough, and strict variant behavior

## Design Decisions

- Reader is called exactly once with the full limit value — no chunked reads or retries. This keeps the contract simple and predictable.
- Non-positive limits are clamped to 0, consistent with `detect_with_limit`.
- Reader errors map to `Error(Nil)` in strict mode and `default_mime_type` in non-strict mode, following the established pattern.

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reader-based MIME type detection supporting custom data sources and flexible byte reading.
  * Introduced strict detection mode with enhanced error handling for failed reads.

* **Tests**
  * Added comprehensive test coverage for reader-based detection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->