### PR TITLE
fix(magic): detect video/mp4 from any ftyp brand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Fixed
+
+- Recognize MP4 files using ISO BMFF brands beyond the previously enumerated
+  set (`isom`, `iso2`, `mp41`, `mp42`, `avc1`). Any input with `ftyp` at offset
+  4 and a full 4-byte brand at offset 8 is now classified as `video/mp4`,
+  unless a more specific signature matches first (`avif`/`avis` → `image/avif`,
+  `heic`/`heix`/`hevc` → `image/heic`, `M4A `/`M4B `/`M4P ` → `audio/mp4`,
+  `qt  ` → `video/quicktime`). Brands such as `M4V `, `f4v `, `MSNV`, `NDAS`,
+  `dash`, and `mp71` are no longer reported as `application/octet-stream`.
+  (#49)
+
 ## [0.3.0] - 2026-04-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
   set (`isom`, `iso2`, `mp41`, `mp42`, `avc1`). Any input with `ftyp` at offset
   4 and a full 4-byte brand at offset 8 is now classified as `video/mp4`,
   unless a more specific signature matches first (`avif`/`avis` → `image/avif`,
-  `heic`/`heix`/`hevc` → `image/heic`, `M4A `/`M4B `/`M4P ` → `audio/mp4`,
-  `qt  ` → `video/quicktime`). Brands such as `M4V `, `f4v `, `MSNV`, `NDAS`,
-  `dash`, and `mp71` are no longer reported as `application/octet-stream`.
+  `heic`/`heix`/`hevc` → `image/heic`, `` M4A  ``/`` M4B  ``/`` M4P  `` →
+  `audio/mp4`, `` qt   `` → `video/quicktime`). Brands such as `` M4V  ``,
+  `` f4v  ``, `MSNV`, `NDAS`, `dash`, and `mp71` are no longer reported as
+  `application/octet-stream`.
   (#49)
 
 ## [0.3.0] - 2026-04-27

--- a/src/mimetype/internal/magic.gleam
+++ b/src/mimetype/internal/magic.gleam
@@ -212,11 +212,7 @@ const signatures = [
   Bytes("audio/mp4", [#(4, <<"ftyp":utf8>>), #(8, <<"M4B ":utf8>>)]),
   Bytes("audio/mp4", [#(4, <<"ftyp":utf8>>), #(8, <<"M4P ":utf8>>)]),
   Bytes("video/quicktime", [#(4, <<"ftyp":utf8>>), #(8, <<"qt  ":utf8>>)]),
-  Bytes("video/mp4", [#(4, <<"ftyp":utf8>>), #(8, <<"isom":utf8>>)]),
-  Bytes("video/mp4", [#(4, <<"ftyp":utf8>>), #(8, <<"iso2":utf8>>)]),
-  Bytes("video/mp4", [#(4, <<"ftyp":utf8>>), #(8, <<"mp41":utf8>>)]),
-  Bytes("video/mp4", [#(4, <<"ftyp":utf8>>), #(8, <<"mp42":utf8>>)]),
-  Bytes("video/mp4", [#(4, <<"ftyp":utf8>>), #(8, <<"avc1":utf8>>)]),
+  Check("video/mp4", looks_like_iso_bmff_video),
   Check("application/json", looks_like_json),
   Check("text/html", looks_like_html),
   Check("image/svg+xml", looks_like_svg),
@@ -289,6 +285,18 @@ fn has_zstd_frame(bytes: BitArray) -> Bool {
     -> True
     _ -> False
   }
+}
+
+// ISO Base Media File Format catch-all for `video/mp4`.
+//
+// Reached only after the specific ftyp brand signatures (avif/avis, heic/heix/
+// hevc, M4A/M4B/M4P, qt) have been tried and missed. Any remaining file with
+// `ftyp` at offset 4 and a full 4-byte brand at offset 8 is treated as
+// `video/mp4` rather than rejected, so brands like `M4V `, `f4v `, `MSNV`,
+// `NDAS`, `dash`, `mp71`, etc. are no longer reported as
+// `application/octet-stream`.
+fn looks_like_iso_bmff_video(bytes: BitArray) -> Bool {
+  has_bytes_at(bytes, 4, <<"ftyp":utf8>>) && bit_array.byte_size(bytes) >= 12
 }
 
 fn has_bytes_at(bytes: BitArray, offset: Int, prefix: BitArray) -> Bool {

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -613,6 +613,30 @@ pub fn detect_mp4_family_formats_test() {
   should_detect(<<0:size(32), "ftyp":utf8, "isom":utf8>>, "video/mp4")
 }
 
+pub fn detect_mp4_recognizes_extra_iso_bmff_brands_test() {
+  // Brands not previously enumerated are now classified as video/mp4 via the
+  // ftyp catch-all (issue #49). The brand bytes are arbitrary 4-byte tokens,
+  // so brands beyond the well-known set should also resolve to video/mp4.
+  should_detect(<<0:size(32), "ftyp":utf8, "M4V ":utf8>>, "video/mp4")
+  should_detect(<<0:size(32), "ftyp":utf8, "f4v ":utf8>>, "video/mp4")
+  should_detect(<<0:size(32), "ftyp":utf8, "MSNV":utf8>>, "video/mp4")
+  should_detect(<<0:size(32), "ftyp":utf8, "NDAS":utf8>>, "video/mp4")
+  should_detect(<<0:size(32), "ftyp":utf8, "dash":utf8>>, "video/mp4")
+  should_detect(<<0:size(32), "ftyp":utf8, "mp71":utf8>>, "video/mp4")
+  should_detect(<<0:size(32), "ftyp":utf8, "XYZQ":utf8>>, "video/mp4")
+}
+
+pub fn detect_mp4_specific_brands_take_precedence_over_catch_all_test() {
+  // The image/heic, audio/mp4 and video/quicktime brand mappings still win
+  // against the ftyp catch-all because the specific signatures are evaluated
+  // first.
+  should_detect(<<0:size(32), "ftyp":utf8, "heix":utf8>>, "image/heic")
+  should_detect(<<0:size(32), "ftyp":utf8, "hevc":utf8>>, "image/heic")
+  should_detect(<<0:size(32), "ftyp":utf8, "avis":utf8>>, "image/avif")
+  should_detect(<<0:size(32), "ftyp":utf8, "M4B ":utf8>>, "audio/mp4")
+  should_detect(<<0:size(32), "ftyp":utf8, "M4P ":utf8>>, "audio/mp4")
+}
+
 pub fn detect_near_miss_signatures_fall_back_to_default_test() {
   // ASCII near-miss falls through to text/plain after #20.
   should_detect(<<"GIF87b":utf8>>, "text/plain")

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -605,6 +605,12 @@ pub fn detect_incomplete_mp4_brand_falls_back_to_default_test() {
   |> should.equal("application/octet-stream")
 }
 
+pub fn detect_partial_mp4_brand_falls_back_to_default_test() {
+  // 11 bytes: ftyp at 4-7 plus only 3 of the 4 brand bytes. The catch-all
+  // requires `byte_size >= 12`, so this must not match video/mp4.
+  should_fall_back(<<0:size(32), "ftyp":utf8, "abc":utf8>>)
+}
+
 pub fn detect_mp4_family_formats_test() {
   should_detect(<<0:size(32), "ftyp":utf8, "avif":utf8>>, "image/avif")
   should_detect(<<0:size(32), "ftyp":utf8, "heic":utf8>>, "image/heic")


### PR DESCRIPTION
## Summary

The magic-number detector for MP4 files only recognized a hard-coded set of
`ftyp` brands (`isom`, `iso2`, `mp41`, `mp42`, `avc1`), so common real-world
brands such as `M4V `, `f4v `, `MSNV`, `NDAS`, `dash`, and `mp71` were
classified as `application/octet-stream`. Replace the brand allowlist with a
catch-all: any input whose offset 4 holds `ftyp` and whose offset 8 carries a
full 4-byte brand is now reported as `video/mp4`, while the more specific
brand mappings continue to win when applicable.

## Changes

- `src/mimetype/internal/magic.gleam`: drop the five fixed `video/mp4` `Bytes`
  signatures and add `Check("video/mp4", looks_like_iso_bmff_video)` after the
  remaining specific ftyp checks; introduce `looks_like_iso_bmff_video/1`
  which verifies `ftyp` at offset 4 and a 4-byte brand at offset 8.
- `test/mimetype_test.gleam`: add
  `detect_mp4_recognizes_extra_iso_bmff_brands_test` covering brands such as
  `M4V `, `f4v `, `MSNV`, `NDAS`, `dash`, `mp71`, and an arbitrary 4-byte
  token; add `detect_mp4_specific_brands_take_precedence_over_catch_all_test`
  to lock in that `heix`, `hevc`, `avis`, `M4B `, `M4P ` keep their specific
  MIME types.
- `CHANGELOG.md`: record the fix under the new `### Fixed` block of
  `## Unreleased`.

## Design Decisions

- **Catch-all instead of an expanded allowlist.** ISO/IEC 14496-12 keeps
  introducing new brands; an enumerated list is fragile. Detecting any valid
  ftyp box and defaulting unknown brands to `video/mp4` matches the issue's
  request and avoids future maintenance churn.
- **Position the catch-all after the specific ftyp signatures.** Because
  `list.find_map` stops at the first match, `image/avif`, `image/heic`,
  `audio/mp4`, and `video/quicktime` mappings continue to take precedence;
  the catch-all only fires for brands the specific signatures did not claim.
- **Require offset 8 to be present (>= 12 bytes).** Preserves the existing
  guarantee from `detect_incomplete_mp4_brand_falls_back_to_default_test` that
  an `ftyp` box without a brand falls through to `application/octet-stream`,
  so the fix does not loosen behavior on truncated inputs.

## Limitations

- The catch-all does not currently inspect compatible-brand entries past the
  major brand at offset 8; a file whose major brand happens to be one of the
  more specific brands (e.g. `heic`) is still treated as `image/heic` even
  if the broader compatible list suggests `video/mp4`. This matches the
  existing behavior and is outside the scope of the issue.

Closes #49


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced MP4 file MIME type detection to recognize additional brand variants, preventing fallback to generic binary classification. Specific MIME types (AVIF, HEIC, audio) continue to take precedence.

* **Tests**
  * Added test coverage for MP4 variant detection and MIME type specificity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->