### PR TITLE
perf(erlang): cache MIME-DB tables in persistent_term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Changed
+
+- Cache the Erlang FFI MIME-DB lookup tables via `persistent_term`. The
+  previous implementation rebuilt the full ~900-entry `extension_to_mime_table`
+  and `mime_type_to_extensions_table` maps on every call to
+  `extension_to_mime_type/1` or `mime_type_to_extensions/1`, allocating fresh
+  maps per invocation and adding GC pressure on hot paths (e.g.
+  Content-Type detection per HTTP request). The tables are now built lazily on
+  first access and reused for the lifetime of the VM. The JavaScript target
+  was already module-level cached and is unchanged. (#48)
+
 ### Fixed
 
 - Recognize MP4 files using ISO BMFF brands beyond the previously enumerated

--- a/scripts/generate_mime_db.sh
+++ b/scripts/generate_mime_db.sh
@@ -100,16 +100,39 @@ EOF
 -module(mimetype_db_ffi).
 -export([extension_to_mime_type/1, mime_type_to_extensions/1]).
 
+-define(EXTENSION_TO_MIME_KEY, {?MODULE, extension_to_mime_table}).
+-define(MIME_TO_EXTENSIONS_KEY, {?MODULE, mime_type_to_extensions_table}).
+
 extension_to_mime_type(Extension) ->
-    case maps:find(Extension, extension_to_mime_table()) of
+    case maps:find(Extension, get_extension_to_mime_table()) of
         {ok, MimeType} -> {ok, MimeType};
         error -> {error, nil}
     end.
 
 mime_type_to_extensions(MimeType) ->
-    case maps:find(MimeType, mime_type_to_extensions_table()) of
+    case maps:find(MimeType, get_mime_type_to_extensions_table()) of
         {ok, Extensions} -> {ok, Extensions};
         error -> {error, nil}
+    end.
+
+get_extension_to_mime_table() ->
+    case persistent_term:get(?EXTENSION_TO_MIME_KEY, undefined) of
+        undefined ->
+            Map = extension_to_mime_table(),
+            persistent_term:put(?EXTENSION_TO_MIME_KEY, Map),
+            Map;
+        Map ->
+            Map
+    end.
+
+get_mime_type_to_extensions_table() ->
+    case persistent_term:get(?MIME_TO_EXTENSIONS_KEY, undefined) of
+        undefined ->
+            Map = mime_type_to_extensions_table(),
+            persistent_term:put(?MIME_TO_EXTENSIONS_KEY, Map),
+            Map;
+        Map ->
+            Map
     end.
 
 extension_to_mime_table() ->

--- a/src/mimetype/internal/mimetype_db_ffi.erl
+++ b/src/mimetype/internal/mimetype_db_ffi.erl
@@ -31,16 +31,39 @@
 -module(mimetype_db_ffi).
 -export([extension_to_mime_type/1, mime_type_to_extensions/1]).
 
+-define(EXTENSION_TO_MIME_KEY, {?MODULE, extension_to_mime_table}).
+-define(MIME_TO_EXTENSIONS_KEY, {?MODULE, mime_type_to_extensions_table}).
+
 extension_to_mime_type(Extension) ->
-    case maps:find(Extension, extension_to_mime_table()) of
+    case maps:find(Extension, get_extension_to_mime_table()) of
         {ok, MimeType} -> {ok, MimeType};
         error -> {error, nil}
     end.
 
 mime_type_to_extensions(MimeType) ->
-    case maps:find(MimeType, mime_type_to_extensions_table()) of
+    case maps:find(MimeType, get_mime_type_to_extensions_table()) of
         {ok, Extensions} -> {ok, Extensions};
         error -> {error, nil}
+    end.
+
+get_extension_to_mime_table() ->
+    case persistent_term:get(?EXTENSION_TO_MIME_KEY, undefined) of
+        undefined ->
+            Map = extension_to_mime_table(),
+            persistent_term:put(?EXTENSION_TO_MIME_KEY, Map),
+            Map;
+        Map ->
+            Map
+    end.
+
+get_mime_type_to_extensions_table() ->
+    case persistent_term:get(?MIME_TO_EXTENSIONS_KEY, undefined) of
+        undefined ->
+            Map = mime_type_to_extensions_table(),
+            persistent_term:put(?MIME_TO_EXTENSIONS_KEY, Map),
+            Map;
+        Map ->
+            Map
     end.
 
 extension_to_mime_table() ->

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -98,6 +98,34 @@ pub fn mime_type_to_extensions_ignores_parameters_test() {
   |> should.equal(["html", "htm", "shtml"])
 }
 
+pub fn extension_to_mime_type_repeated_lookups_are_consistent_test() {
+  // Regression for issue #48: the Erlang FFI now caches the lookup tables
+  // via persistent_term. Repeated lookups (mixing the same key, different
+  // keys, and unknown keys) must keep returning the same answers.
+  list.repeat(Nil, 200)
+  |> list.each(fn(_) {
+    mimetype.extension_to_mime_type(".json")
+    |> should.equal("application/json")
+    mimetype.extension_to_mime_type(".png")
+    |> should.equal("image/png")
+    mimetype.extension_to_mime_type("totally-unknown-ext")
+    |> should.equal("application/octet-stream")
+  })
+}
+
+pub fn mime_type_to_extensions_repeated_lookups_are_consistent_test() {
+  // Regression for issue #48: matching coverage on the reverse-lookup map.
+  list.repeat(Nil, 200)
+  |> list.each(fn(_) {
+    mimetype.mime_type_to_extensions("image/jpeg")
+    |> should.equal(["jpg", "jpeg", "jpe"])
+    mimetype.mime_type_to_extensions("application/json")
+    |> should.equal(["json", "map"])
+    mimetype.mime_type_to_extensions("application/x-not-real")
+    |> should.equal([])
+  })
+}
+
 pub fn essence_strips_parameters_and_normalizes_case_test() {
   mimetype.essence(" TEXT/HTML ; charset=UTF-8 ")
   |> should.equal("text/html")


### PR DESCRIPTION
## Summary

On the Erlang target, every call to `mimetype.extension_to_mime_type/1` and
`mimetype.mime_type_to_extensions/1` rebuilt the full ~900-entry MIME-DB map
from a literal expression, allocating a fresh map per invocation. This caused
unnecessary GC pressure on hot paths (e.g. Content-Type detection per HTTP
request). Cache the two tables in `persistent_term` on first access so
subsequent calls reuse the same map. The JavaScript target was already
module-level cached and is unchanged.

## Changes

- `src/mimetype/internal/mimetype_db_ffi.erl`: introduce
  `get_extension_to_mime_table/0` and `get_mime_type_to_extensions_table/0`
  wrappers that lazily populate `persistent_term` keys
  `{mimetype_db_ffi, extension_to_mime_table}` /
  `{mimetype_db_ffi, mime_type_to_extensions_table}` on the first lookup.
  `extension_to_mime_type/1` and `mime_type_to_extensions/1` now read from
  these wrappers; the literal-map builder functions remain so the data is
  computed exactly once per VM lifetime.
- `scripts/generate_mime_db.sh`: emit the same wrapper functions and
  `persistent_term` keys when regenerating the FFI module so future
  regenerations stay byte-identical with the committed file.
- `test/mimetype_test.gleam`: add
  `extension_to_mime_type_repeated_lookups_are_consistent_test` and
  `mime_type_to_extensions_repeated_lookups_are_consistent_test`. Each
  performs 200 iterations of mixed lookups (known keys, alternate known keys,
  unknown keys) on both maps to catch any caching regressions, including
  stale-state bugs that would only surface after the first persistent_term
  hit.
- `CHANGELOG.md`: record the optimization under a new `### Changed` block in
  `## Unreleased`.

## Design Decisions

- **`persistent_term` over ETS / module attribute / process dictionary.**
  `persistent_term` gives O(1) reads with no copy of the term per call once
  populated, which exactly matches the access pattern (read-mostly,
  module-scope, never updated after init). ETS would still copy per read; a
  process dictionary is per-process and would not be shared; module
  attributes are read-only at compile time and force the same literal
  reconstruction the issue is fixing.
- **Lazy initialization rather than `on_load`.** The module is generated and
  has no hand-written hooks, so wiring an `on_load` callback would expand the
  generator's surface area. Lazy population on first call is simpler,
  idempotent under concurrent first-access, and pays the build cost only if
  the function is ever called.
- **`persistent_term:get/2` with a sentinel `undefined` default.** Avoids the
  try/catch for the missing-key path and keeps the hot path a single map
  read. Concurrent first-access by multiple processes is safe: each may
  build the map locally, but `persistent_term:put/2` is idempotent, the term
  contents are identical, and the steady state still ends with one shared
  copy.
- **Generator and committed file kept in lockstep.** The repo enforces
  `Generated MIME-DB matches script output` in CI; both are updated together
  so that check stays green.

## Limitations

- `persistent_term:put/2` triggers a global GC on the first call to walk
  process heaps for stale references. This is a one-time cost paid once per
  table at process-tree warm-up, which is the standard trade-off documented
  in `persistent_term`'s OTP guide and is amortized away by every subsequent
  lookup.

Closes #48
