### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.4.0] - 2026-04-27
+
 ### Changed
 
 - Cache the Erlang FFI MIME-DB lookup tables via `persistent_term`. The

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "mimetype"
-version = "0.3.0"
+version = "0.4.0"
 description = "MIME type lookup and magic-number detection for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "mimetype" }


### PR DESCRIPTION
### Changed

- Cache the Erlang FFI MIME-DB lookup tables via `persistent_term`. The
  previous implementation rebuilt the full ~900-entry `extension_to_mime_table`
  and `mime_type_to_extensions_table` maps on every call to
  `extension_to_mime_type/1` or `mime_type_to_extensions/1`, allocating fresh
  maps per invocation and adding GC pressure on hot paths (e.g.
  Content-Type detection per HTTP request). The tables are now built lazily on
  first access and reused for the lifetime of the VM. The JavaScript target
  was already module-level cached and is unchanged. (#48)

### Fixed

- Recognize MP4 files using ISO BMFF brands beyond the previously enumerated
  set (`isom`, `iso2`, `mp41`, `mp42`, `avc1`). Any input with `ftyp` at offset
  4 and a full 4-byte brand at offset 8 is now classified as `video/mp4`,
  unless a more specific signature matches first (`avif`/`avis` → `image/avif`,
  `heic`/`heix`/`hevc` → `image/heic`, `` M4A  ``/`` M4B  ``/`` M4P  `` →
  `audio/mp4`, `` qt   `` → `video/quicktime`). Brands such as `` M4V  ``,
  `` f4v  ``, `MSNV`, `NDAS`, `dash`, and `mp71` are no longer reported as
  `application/octet-stream`.
  (#49)
