### PR TITLE
docs(README): describe actual text/plain and BOM sniffing behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Documentation
+
+- README correctly describes what the library does and does not sniff.
+  The previous wording claimed `mimetype` "does not detect text encodings
+  or sniff `text/plain` heuristically" and "does not currently expose
+  dedicated charset or MIME-parameter parsing helpers" — both contradicted
+  the printable-ASCII heuristic added in #20 and the four UTF-BOM
+  signatures (which surface `text/plain; charset=utf-*`). The relevant
+  bullets now describe the actual behaviour: bare `text/plain` for
+  printable-ASCII payloads, `text/plain; charset=<utf-X>` for the four
+  BOM signatures, and no other MIME-parameter parsing or text-encoding
+  detection. (#53)
+
 ## [0.4.0] - 2026-04-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ the generated table keeps lookups aligned with that upstream source.
 This library intentionally stays focused:
 
 - It does not do deep container introspection such as distinguishing Office formats inside ZIP
-- It does not detect text encodings or sniff `text/plain` heuristically
-- It does not currently expose dedicated charset or MIME-parameter parsing helpers
+- It does sniff `text/plain` from printable-ASCII-only payloads (the bounded WHATWG-style binary-vs-text heuristic added in #20) and recognises the UTF-8/16/32 BOM signatures, returning `text/plain; charset=<utf-X>` for the BOM cases. This is the **only** text-related sniffing — it does not detect text encodings beyond the BOM marker, and the printable-ASCII fallback emits a bare `text/plain` with no charset parameter.
+- Beyond the four BOM-derived `text/plain; charset=utf-*` signatures it does not parse, validate, or surface MIME-parameter values from the wire.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Fixes Issue #53. The README's "intentionally stays focused" section
contradicted the actual implementation:

- **Claim**: "does not detect text encodings or sniff `text/plain`
  heuristically".
  **Reality**: `magic.gleam:226` registers `Check("text/plain",
  looks_like_plain_text)`, a bounded WHATWG-style printable-ASCII
  heuristic that emits bare `text/plain` whenever no other signature
  matches and the payload is all printable. Added in #20.
- **Claim**: "does not currently expose dedicated charset or
  MIME-parameter parsing helpers".
  **Reality**: `magic.gleam:221-225` registers four UTF-BOM signatures
  that emit `text/plain; charset=utf-{8,16le,16be,32le,32be}` —
  charset parameters on the wire.

Per the issue's smaller-fix recommendation, this PR updates the README
to describe the actual behaviour (printable-ASCII heuristic for bare
`text/plain`, BOM signatures for `text/plain; charset=*`, no other
text-encoding detection or MIME-parameter parsing) rather than gating
the existing sniffing behind a flag.

## Changes

- `README.md`: rewrites the two bullet points so they match the code.
  The "no Office introspection inside ZIP" caveat stays unchanged.
- `CHANGELOG.md`: documents the README fix under `### Documentation`
  in the Unreleased section.

## Design Decisions

- **Update docs, don't change behaviour.** The text/plain heuristic was
  introduced intentionally in #20 as a usability fix. Reverting it would
  regress that issue. The minimal correct change is to make the README
  reflect what the library actually does.
- **No code change.** This is a docs-only PR.

## Test Plan

- [x] `gleam format --check src/ test/` — clean.
- [x] `gleam test` — 269 passes (no behaviour change, baseline preserved).
- [x] Re-read the updated README bullets against the magic table in
  `src/mimetype/internal/magic.gleam` to confirm they describe the
  actual `Check`/`Bytes` entries.

Closes #53
