### PR TITLE
docs(detect): document the application/octet-stream fallback contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Documentation
 
+- `detect/1` and `detect_strict/1` docstrings now spell out the
+  fallback contract: `detect/1` returns `"application/octet-stream"`
+  (the value of `default_mime_type`) for any input with no recognisable
+  magic bytes, including the empty `BitArray`, while `detect_strict/1`
+  returns `Error(Nil)` for the same case so callers can tell "no
+  signature found" from "signature found". The README's `detect`
+  example block also shows the empty-input + `detect_strict/1` pair so
+  the choice between the two surfaces near the first usage line. (#54)
 - README correctly describes what the library does and does not sniff.
   The previous wording claimed `mimetype` "does not detect text encodings
   or sniff `text/plain` heuristically" and "does not currently expose

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ pub fn main() {
   mimetype.detect(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>)
   // -> "image/png"
 
+  mimetype.detect(<<>>)
+  // -> "application/octet-stream"  (silent fallback for unknown / empty input)
+
+  mimetype.detect_strict(<<>>)
+  // -> Error(Nil)  (loud variant — distinguishes "no signature" from a match)
+
   mimetype.detect_with_filename(<<0, 1, 2, 3>>, "report.csv")
   // -> "text/csv"
 }

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -259,8 +259,13 @@ pub fn filename_to_mime_type_strict(path: String) -> Result(String, Nil) {
 /// `image/avif`, `image/heic`, `video/x-msvideo`, `video/webm`,
 /// `video/quicktime`, and `video/mp4`.
 ///
-/// If no signature matches, the default fallback MIME type is
-/// returned.
+/// Returns `"application/octet-stream"` (the value of
+/// `default_mime_type`) when the input carries no recognisable magic
+/// bytes — including the empty `BitArray`. The fallback is silent: a
+/// caller that needs to distinguish "no signature matched" from
+/// "signature matched but produced `application/octet-stream`" should
+/// use `detect_strict/1`, which returns `Error(Nil)` for the
+/// no-match case.
 pub fn detect(bytes: BitArray) -> String {
   detect_with_limit(bytes, default_detection_limit)
 }
@@ -268,7 +273,11 @@ pub fn detect(bytes: BitArray) -> String {
 /// Detect a MIME type from the leading bytes of a blob.
 ///
 /// This strict variant returns `Error(Nil)` when no supported
-/// magic-number signature matches.
+/// magic-number signature matches the input (including the empty
+/// `BitArray`), so the caller can distinguish "no signature found"
+/// from "signature matched". Prefer this variant when the
+/// `application/octet-stream` fallback would be ambiguous; use
+/// `detect/1` when an unconditional `String` is more convenient.
 pub fn detect_strict(bytes: BitArray) -> Result(String, Nil) {
   detect_with_limit_strict(bytes, default_detection_limit)
 }


### PR DESCRIPTION
## Summary

Fixes Issue #54. `detect/1`'s docstring said "the default fallback
MIME type is returned" without naming the actual value
(`application/octet-stream`) or noting that the empty `BitArray`
falls into the same bucket. `detect_strict/1` mentioned the
`Error(Nil)` return type but didn't explain when a caller would
prefer it. This PR makes the contract explicit on both sides and
shows the loud/quiet pair next to the existing `detect` example
in the README.

## Changes

- `src/mimetype.gleam`: rewrites the closing paragraph of
  `detect/1`'s docstring to name `application/octet-stream`
  (`default_mime_type`) explicitly, call out that the empty
  `BitArray` lands in the fallback, and recommend `detect_strict/1`
  when the caller needs to distinguish "no match" from "match".
  Symmetrically expands `detect_strict/1` so the trade-off is
  documented from both directions.
- `README.md`: adds two lines under the existing `detect` example
  that demonstrate the empty-input fallback and the
  `detect_strict(<<>>)` `Error(Nil)` return, so a reader scanning
  the usage block sees the loud/quiet variant pairing immediately.
- `CHANGELOG.md`: records the docstring + README clarifications under
  `### Documentation` in the Unreleased section.

## Design Decisions

- **Docstring + README, not a "choosing a function" table.** The
  issue suggested a table in the README; in practice the choice
  between `detect/1` and `detect_strict/1` is the only one users
  hit at this layer (the `_with_*` helpers all follow the same
  loud/quiet pattern). A two-line example pairing keeps the
  README compact while still surfacing the distinction.
- **No code change.** This is a docs-only PR. Behaviour is
  unchanged.

## Test Plan

- [x] `gleam format --check src/ test/` — clean.
- [x] `gleam test` — 269 passes (no behaviour change, baseline
  preserved).
- [x] Re-read the docstring against the actual `detect_with_limit`
  / `detect_with_limit_strict` paths to confirm the empty-input and
  no-match branches really do return `default_mime_type` /
  `Error(Nil)` respectively.

Closes #54
