### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.5.0] - 2026-04-28
+
 ### Documentation
 
 - `detect/1` and `detect_strict/1` docstrings now spell out the

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "mimetype"
-version = "0.4.0"
+version = "0.5.0"
 description = "MIME type lookup and magic-number detection for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "mimetype" }


### PR DESCRIPTION
## Release v0.5.0

Documentation-only release. Two README/docstring fixes that close
the open Issue queue.

### Highlights — non-breaking

- **`detect/1` and `detect_strict/1` fallback contract documented
  (#54).** `detect/1` returns `"application/octet-stream"` (the
  value of `default_mime_type`) for any input with no recognisable
  magic bytes — including the empty `BitArray` — and
  `detect_strict/1` returns `Error(Nil)` for the same case so
  callers can distinguish "no signature found" from "signature
  found". The README's `detect` example now shows the empty-input
  + `detect_strict/1` pair next to the existing usage so the
  loud / quiet variant choice surfaces near the first usage line.
- **README correctly describes the `text/plain` and BOM sniffing
  behaviour (#53).** The previous wording claimed mimetype "does
  not detect text encodings or sniff `text/plain` heuristically"
  and "does not currently expose dedicated charset or
  MIME-parameter parsing helpers", both of which contradicted the
  printable-ASCII heuristic added in #20 and the four UTF-BOM
  signatures (which surface `text/plain; charset=utf-*`). The
  bullets now describe the actual behaviour: bare `text/plain` for
  printable-ASCII payloads, `text/plain; charset=<utf-X>` for the
  four BOM signatures, and no other MIME-parameter parsing or
  text-encoding detection.

### Coverage

- 269 unit tests; baseline preserved (no behaviour change in this
  release).
- `gleam format --check src/ test/` and `gleam test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
