### PR TITLE
fix(detect): prefer filename hint over printable-ASCII fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+### Fixed
+
+- `detect_with_filename/2` and `detect_with_extension/2` now consult
+  the filename / extension hint when the byte signature side only
+  matched the printable-ASCII fallback. Previously the
+  printable-ASCII heuristic was treated as a "match", so a `.csv`
+  filename paired with CSV content returned `text/plain` and the
+  filename hint was silently ignored — defeating the canonical use
+  case ("I have an upload, here's a `.csv` filename hint, give me
+  a sensible Content-Type"). Genuine binary or structural signatures
+  (PNG, JPEG, ZIP, JSON / HTML / XML / SVG, BOM-tagged text, ...)
+  still take priority over the filename hint. The printable-ASCII
+  heuristic remains the last-resort fallback when neither the byte
+  signature nor the filename's extension is recognisable. (#58)
+
+### Added
+
+- `detect_signature_only/1` and `detect_signature_only_with_limit/2`
+  expose the "genuine signature only" detection path: real magic
+  numbers and structural sniffs return `Ok(mime_type)`, plain-ASCII
+  payloads return `Error(Nil)`. This is the building block behind
+  the `detect_with_filename` / `detect_with_extension` fix above and
+  is useful for callers that want to compose their own fallback
+  shape against a stronger out-of-band hint. (#58)
+
 ## [0.5.0] - 2026-04-28
 
 ### Documentation

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -306,6 +306,34 @@ pub fn detect_with_limit_strict(
   result_from_option(magic.detect(truncate_to_limit(bytes, limit)))
 }
 
+/// Detect a MIME type from a genuine binary or structural signature
+/// only.
+///
+/// Like `detect_strict` but excludes the printable-ASCII heuristic that
+/// otherwise classifies every plain-ASCII payload as `text/plain`.
+/// Returns `Ok(mime_type)` for byte magic numbers (PNG, JPEG, ZIP,
+/// `text/plain; charset=utf-*` BOMs, ...) and structural sniffs that
+/// inspect bytes (JSON, HTML, XML, SVG). Returns `Error(Nil)` for
+/// arbitrary printable-ASCII text — letting the caller defer to a
+/// stronger out-of-band hint such as a filename extension.
+///
+/// This is the building block behind `detect_with_filename` /
+/// `detect_with_extension`: a `.csv` filename is a stronger signal
+/// than the byte-level fact "this is printable ASCII", so those
+/// helpers consult the filename hint when the only thing the byte
+/// side could say was `text/plain`.
+pub fn detect_signature_only(bytes: BitArray) -> Result(String, Nil) {
+  detect_signature_only_with_limit(bytes, default_detection_limit)
+}
+
+/// `detect_signature_only` with an explicit byte budget.
+pub fn detect_signature_only_with_limit(
+  bytes: BitArray,
+  limit: Int,
+) -> Result(String, Nil) {
+  result_from_option(magic.detect_signature(truncate_to_limit(bytes, limit)))
+}
+
 fn truncate_to_limit(bytes: BitArray, limit: Int) -> BitArray {
   let size = bit_array.byte_size(bytes)
   let safe_limit = case limit < 0, limit > size {
@@ -352,11 +380,17 @@ pub fn detect_reader_strict(read: Reader, limit: Int) -> Result(String, Nil) {
   }
 }
 
-/// Detect a MIME type from bytes, falling back to an explicit
-/// extension when the content signature is unknown.
+/// Detect a MIME type from bytes, consulting an explicit extension
+/// hint when the byte signature alone is not specific enough.
 ///
-/// This helper prefers the byte signature over the extension if the
-/// two disagree.
+/// Genuine binary signatures (PNG, JPEG, ZIP, BOM-tagged text, ...) and
+/// structural sniffs (JSON, HTML, XML, SVG) win over the extension
+/// hint. The extension takes priority when the only thing the byte
+/// side could say was the printable-ASCII fallback `text/plain` — a
+/// `.csv` extension is a stronger signal for plain-ASCII payloads than
+/// the byte-level fact "this looks textish". The printable-ASCII
+/// fallback is still used as a last resort when neither the byte
+/// signature nor the extension is recognisable.
 pub fn detect_with_extension(bytes: BitArray, extension: String) -> String {
   case detect_with_extension_strict(bytes, extension) {
     Ok(mime_type) -> mime_type
@@ -364,26 +398,37 @@ pub fn detect_with_extension(bytes: BitArray, extension: String) -> String {
   }
 }
 
-/// Detect a MIME type from bytes, falling back to an explicit
-/// extension when the content signature is unknown.
+/// Detect a MIME type from bytes, consulting an explicit extension
+/// hint when the byte signature alone is not specific enough.
 ///
 /// This strict variant returns `Error(Nil)` only when neither the byte
-/// signature nor the normalized extension are known.
+/// signature, the normalised extension, nor the printable-ASCII
+/// fallback succeed.
 pub fn detect_with_extension_strict(
   bytes: BitArray,
   extension: String,
 ) -> Result(String, Nil) {
-  case detect_strict(bytes) {
+  case detect_signature_only(bytes) {
     Ok(mime_type) -> Ok(mime_type)
-    Error(Nil) -> extension_to_mime_type_strict(extension)
+    Error(Nil) ->
+      case extension_to_mime_type_strict(extension) {
+        Ok(mime_type) -> Ok(mime_type)
+        Error(Nil) -> detect_strict(bytes)
+      }
   }
 }
 
-/// Detect a MIME type from bytes, falling back to the filename
-/// extension when the content signature is unknown.
+/// Detect a MIME type from bytes, consulting the filename extension
+/// when the byte signature alone is not specific enough.
 ///
-/// This helper prefers the byte signature over the filename if the two
-/// disagree.
+/// Genuine binary signatures (PNG, JPEG, ZIP, BOM-tagged text, ...) and
+/// structural sniffs (JSON, HTML, XML, SVG) win over the filename. The
+/// filename takes priority when the only thing the byte side could say
+/// was the printable-ASCII fallback `text/plain` — a `report.csv`
+/// filename is a stronger signal for plain-ASCII payloads than the
+/// byte-level fact "this looks textish". The printable-ASCII fallback
+/// is still used as a last resort when neither the byte signature nor
+/// the filename's extension is recognisable.
 pub fn detect_with_filename(bytes: BitArray, filename: String) -> String {
   case detect_with_filename_strict(bytes, filename) {
     Ok(mime_type) -> mime_type
@@ -391,18 +436,23 @@ pub fn detect_with_filename(bytes: BitArray, filename: String) -> String {
   }
 }
 
-/// Detect a MIME type from bytes, falling back to the filename
-/// extension when the content signature is unknown.
+/// Detect a MIME type from bytes, consulting the filename extension
+/// when the byte signature alone is not specific enough.
 ///
 /// This strict variant returns `Error(Nil)` only when neither the byte
-/// signature nor the filename extension are known.
+/// signature, the filename extension, nor the printable-ASCII fallback
+/// succeed.
 pub fn detect_with_filename_strict(
   bytes: BitArray,
   filename: String,
 ) -> Result(String, Nil) {
-  case detect_strict(bytes) {
+  case detect_signature_only(bytes) {
     Ok(mime_type) -> Ok(mime_type)
-    Error(Nil) -> filename_to_mime_type_strict(filename)
+    Error(Nil) ->
+      case filename_to_mime_type_strict(filename) {
+        Ok(mime_type) -> Ok(mime_type)
+        Error(Nil) -> detect_strict(bytes)
+      }
   }
 }
 

--- a/src/mimetype/internal/magic.gleam
+++ b/src/mimetype/internal/magic.gleam
@@ -237,6 +237,35 @@ pub fn detect(bytes: BitArray) -> Option(String) {
   }
 }
 
+/// Like `detect` but excludes the printable-ASCII heuristic.
+///
+/// Returns `Some(mime_type)` only for genuine signature matches: byte
+/// magic numbers (PNG, JPEG, ZIP, ...) and structural sniffs that
+/// inspect bytes (JSON, HTML, XML, SVG). Returns `None` for plain-ASCII
+/// payloads where `detect` would have returned `Some("text/plain")`.
+pub fn detect_signature(bytes: BitArray) -> Option(String) {
+  let result =
+    signatures
+    |> list.filter(fn(signature) { !is_printable_ascii_fallback(signature) })
+    |> list.find_map(detect_match(bytes, _))
+  case result {
+    Ok(mime_type) -> Some(mime_type)
+    Error(Nil) -> None
+  }
+}
+
+// The printable-ASCII fallback is the only `Check("text/plain", _)`
+// entry in `signatures`: every other `text/plain` entry uses `Bytes`
+// to match a specific BOM. Filtering on this shape keeps
+// `detect_signature` from accepting plain-ASCII text as a "real"
+// signature match while still returning the BOM-tagged variants.
+fn is_printable_ascii_fallback(signature: Signature) -> Bool {
+  case signature {
+    Check("text/plain", _) -> True
+    _ -> False
+  }
+}
+
 fn detect_match(bytes: BitArray, signature: Signature) -> Result(String, Nil) {
   let mime_type = signature_mime_type(signature)
 

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -747,6 +747,80 @@ pub fn detect_with_filename_prefers_magic_over_extension_test() {
   |> should.equal("image/png")
 }
 
+// Regression: issue #58 — printable-ASCII content used to be treated
+// as a "matched signature" by `detect_with_filename`, so the filename
+// hint was ignored. `text/csv` for `.csv` is the canonical case.
+pub fn detect_with_filename_prefers_filename_over_printable_ascii_csv_test() {
+  let bytes = <<
+    "type,severity,message,occurred_at\nlogin,info,hi,2026-04-28\n":utf8,
+  >>
+  mimetype.detect_with_filename(bytes, "fixtures.csv")
+  |> should.equal("text/csv")
+}
+
+pub fn detect_with_filename_prefers_filename_over_printable_ascii_md_test() {
+  mimetype.detect_with_filename(<<"# Title\n\nbody\n":utf8>>, "dump.md")
+  |> should.equal("text/markdown")
+}
+
+pub fn detect_with_filename_falls_back_to_text_plain_when_filename_unknown_test() {
+  // Plain ASCII + filename without a known extension: the
+  // printable-ASCII heuristic is still the right last resort.
+  mimetype.detect_with_filename(<<"plain text\n":utf8>>, "README")
+  |> should.equal("text/plain")
+}
+
+pub fn detect_with_extension_prefers_extension_over_printable_ascii_csv_test() {
+  mimetype.detect_with_extension(<<"a,b,c\n1,2,3\n":utf8>>, "csv")
+  |> should.equal("text/csv")
+}
+
+pub fn detect_with_extension_strict_prefers_extension_over_printable_ascii_csv_test() {
+  mimetype.detect_with_extension_strict(<<"a,b,c\n1,2,3\n":utf8>>, "csv")
+  |> should.equal(Ok("text/csv"))
+}
+
+pub fn detect_with_extension_falls_back_to_text_plain_when_extension_unknown_test() {
+  mimetype.detect_with_extension(<<"plain text\n":utf8>>, "totally-unknown-ext")
+  |> should.equal("text/plain")
+}
+
+pub fn detect_signature_only_returns_ok_for_binary_signature_test() {
+  mimetype.detect_signature_only(<<
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+  >>)
+  |> should.equal(Ok("image/png"))
+}
+
+pub fn detect_signature_only_returns_ok_for_structural_sniff_test() {
+  mimetype.detect_signature_only(<<"{\"x\":1}":utf8>>)
+  |> should.equal(Ok("application/json"))
+}
+
+pub fn detect_signature_only_returns_ok_for_bom_tagged_text_test() {
+  // BOM-tagged text is a real signature, not the printable-ASCII
+  // heuristic, so it must still be returned.
+  mimetype.detect_signature_only(<<0xEF, 0xBB, 0xBF, "hello":utf8>>)
+  |> should.equal(Ok("text/plain; charset=utf-8"))
+}
+
+pub fn detect_signature_only_returns_error_for_printable_ascii_test() {
+  // The whole point of this helper: plain printable ASCII is *not*
+  // a signature match here.
+  mimetype.detect_signature_only(<<"plain text\n":utf8>>)
+  |> should.equal(Error(Nil))
+}
+
+pub fn detect_signature_only_returns_error_for_empty_test() {
+  mimetype.detect_signature_only(<<>>)
+  |> should.equal(Error(Nil))
+}
+
+pub fn detect_signature_only_returns_error_for_unknown_binary_test() {
+  mimetype.detect_signature_only(<<1, 2, 3, 4>>)
+  |> should.equal(Error(Nil))
+}
+
 pub fn detect_json_empty_object_test() {
   should_detect(<<"{}":utf8>>, "application/json")
 }


### PR DESCRIPTION
## Summary

`detect_with_filename(bytes, filename)` and
`detect_with_extension(bytes, extension)` used to ignore the filename /
extension hint whenever the byte side matched the printable-ASCII
heuristic — so the canonical use case ("upload with a `.csv` filename
hint, give me a sensible Content-Type") returned `text/plain` and the
hint was wasted. This PR restores the documented "filename takes over
when the byte signature is unknown" behaviour for plain-ASCII payloads.

Closes #58.

## Changes

- `src/mimetype/internal/magic.gleam`
  - new `detect_signature/1` returns `Option(String)` only for genuine
    signature matches (BOMs, magic numbers, structural sniffs like
    JSON / HTML / XML / SVG); the printable-ASCII fallback returns
    `None`. The fallback signature is identified via a `Check("text/plain", _)`
    filter — it is the only such entry in `signatures` (the other
    `text/plain` entries are `Bytes` BOM matches).
- `src/mimetype.gleam`
  - new `detect_signature_only/1` and
    `detect_signature_only_with_limit/2` expose the signature-only
    path so callers can compose their own fallback shape.
  - `detect_with_extension_strict/2` and `detect_with_filename_strict/2`
    are rewritten as a three-step ladder: signature-only match →
    extension / filename hint → printable-ASCII last-resort. Genuine
    binary signatures still take priority over the hint; the
    printable-ASCII heuristic is still the last-resort fallback when
    neither side resolves, so existing
    `text/plain`-on-no-other-info callers keep working.
  - docstrings on the four public helpers now explain the
    "filename / extension wins over `text/plain`" rule and drop the
    old "falls back ... when the content signature is unknown"
    framing flagged as misleading in the issue.
- `test/mimetype_test.gleam`: 11 new tests
  - regression for the issue's CSV reproduction (and the parallel
    `.md` and extension-only variants).
  - back-compat coverage: `detect_with_filename` still falls back to
    `text/plain` when the filename has no known extension.
  - `detect_signature_only` happy paths (PNG, JSON, BOM-tagged text)
    and rejects (printable-ASCII, empty, unknown binary).
- `CHANGELOG.md`: `[Unreleased]` block describing the fix and the new
  public helper.

## Design Decisions

- **Public `detect_signature_only` over an internal-only fix.** The
  issue notes this as an orthogonal API addition. Exposing it costs
  nothing (it's the same code path the fix already needs) and lets
  callers with stronger out-of-band hints (`Content-Type` from the
  client, an upload field name, ...) build their own ordering.
- **Last-resort `detect_strict` keeps existing behaviour.** A
  `text/plain` answer is still produced for plain-ASCII payloads
  whose filename / extension is unknown; the previous test suite
  covered that case and the new code continues to satisfy it.
- **Filtering by `Check("text/plain", _)`** rather than introducing a
  new variant. Adds a tiny in-line comment so future signature
  additions know not to add another `Check("text/plain", _)` without
  thinking about this filter.

## Verification

- `just all` passes (format-check, glinter, build for both Erlang and
  JavaScript, `gleam test --target erlang` 281 passed,
  `gleam test --target javascript` 281 passed, docs build).
