### PR TITLE
feat(reader): generic Reader error + structured DetectionError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 ## Unreleased
 
+### Changed
+
+- **Reader (BREAKING)**: `Reader = fn(Int) -> Result(BitArray, String)`
+  is now `Reader(read_error) = fn(Int) -> Result(BitArray, read_error)`.
+  Generic `read_error` lets JS-side readers (FileReader,
+  ReadableStream) and BEAM-side readers (file handles, HTTP clients)
+  preserve their richer error shapes through `detect_reader_strict`
+  instead of being collapsed to a stringly-typed placeholder.
+- **detect_reader_strict (BREAKING)**: returns
+  `Result(String, DetectionError(read_error))` instead of
+  `Result(String, Nil)`. The new `DetectionError(e)` type has two
+  variants: `NoMatch` (the reader produced bytes but no signature
+  matched) and `ReaderError(e)` (the reader itself failed before
+  any bytes could be inspected, carrying the reader's own error
+  through unchanged). Callers can now distinguish a
+  format-recognition failure from an upstream read failure — useful
+  for HTTP upload pipelines that want to render "couldn't read the
+  file" differently from "we don't recognise this format".
+  Migration: the lenient `detect_reader/2` shape is unchanged
+  (still returns `String`); call sites that previously matched
+  `Error(Nil)` against `detect_reader_strict` switch to matching
+  `Error(NoMatch)` or `Error(ReaderError(_))`. (#61, partial)
+
+### Notes
+
+- This is a partial fix toward #61: only the `Reader`-bearing path
+  carries the new structured error. The other `*_strict` functions
+  in the strict family (`extension_to_mime_type_strict`,
+  `filename_to_mime_type_strict`, `detect_strict`,
+  `detect_with_limit_strict`, `detect_signature_only`,
+  `detect_with_extension_strict`, `detect_with_filename_strict`,
+  `parameter`, `charset`, `charset_of`) still return
+  `Result(_, Nil)`. Migrating those to a unified
+  `DetectionError(_)` shape is its own follow-up because each one
+  has a different "no useful answer" reason
+  (`UnknownExtension(_)`, `EmptyInput`, …) that needs a separate
+  modelling pass.
+
 ## [0.6.0] - 2026-04-28
 
 ### Fixed

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -378,7 +378,8 @@ pub type DetectionError(read_error) {
 pub fn detect_reader(read: Reader(read_error), limit: Int) -> String {
   case detect_reader_strict(read, limit) {
     Ok(mime_type) -> mime_type
-    Error(_) -> default_mime_type
+    Error(NoMatch) -> default_mime_type
+    Error(ReaderError(_)) -> default_mime_type
   }
 }
 

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -348,35 +348,63 @@ fn truncate_to_limit(bytes: BitArray, limit: Int) -> BitArray {
 /// input source. Returns `Ok(bits)` with the bytes actually read, or
 /// `Error(reason)` if the read fails. A reader that returns fewer bytes
 /// than requested signals end-of-input.
-pub type Reader =
-  fn(Int) -> Result(BitArray, String)
+///
+/// The error type is generic so JS-side readers (FileReader,
+/// ReadableStream) and BEAM-side readers (file handles, HTTP clients)
+/// can preserve their richer error shapes through `detect_reader_strict`.
+pub type Reader(read_error) =
+  fn(Int) -> Result(BitArray, read_error)
+
+/// Reasons `detect_reader_strict` can return `Error(_)`.
+///
+/// The error is structured so callers can distinguish "no signature
+/// matched" from "the reader itself failed before any bytes could be
+/// inspected" — useful for HTTP upload pipelines that want to render
+/// "couldn't read the file" differently from "we don't recognise this
+/// format". `read_error` is the type the supplied `Reader` produces;
+/// it flows through unchanged when the reader fails.
+pub type DetectionError(read_error) {
+  /// No signature matched the bytes that were inspected.
+  NoMatch
+  /// The reader returned an error before any bytes could be inspected.
+  ReaderError(read_error)
+}
 
 /// Detect a MIME type by pulling at most `limit` leading bytes through
 /// a caller-supplied reader.
 ///
 /// The reader is called once with `limit` as the requested byte count.
 /// If the reader returns an error, the default MIME type is returned.
-pub fn detect_reader(read: Reader, limit: Int) -> String {
+pub fn detect_reader(read: Reader(read_error), limit: Int) -> String {
   case detect_reader_strict(read, limit) {
     Ok(mime_type) -> mime_type
-    Error(Nil) -> default_mime_type
+    Error(_) -> default_mime_type
   }
 }
 
 /// Detect a MIME type by pulling at most `limit` leading bytes through
 /// a caller-supplied reader.
 ///
-/// This strict variant returns `Error(Nil)` when the reader fails or
-/// when no supported magic-number signature matches within the bytes
-/// returned.
-pub fn detect_reader_strict(read: Reader, limit: Int) -> Result(String, Nil) {
+/// Returns `Error(ReaderError(e))` when the reader itself failed, or
+/// `Error(NoMatch)` when the reader produced bytes but no supported
+/// magic-number signature matched within them. The reader's own error
+/// type flows through `ReaderError(_)` unchanged so callers can render
+/// it however they wish.
+pub fn detect_reader_strict(
+  read: Reader(read_error),
+  limit: Int,
+) -> Result(String, DetectionError(read_error)) {
   let safe_limit = case limit < 1 {
     True -> 0
     False -> limit
   }
   case read(safe_limit) {
-    Ok(bytes) -> detect_with_limit_strict(bytes, safe_limit)
-    Error(_) -> Error(Nil)
+    Ok(bytes) ->
+      case detect_with_limit_strict(bytes, safe_limit) {
+        Ok(mime_type) -> Ok(mime_type)
+        Error(Nil) -> Error(NoMatch)
+      }
+    Error(read_error) -> Error(ReaderError(read_error))
   }
 }
 

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -1539,10 +1539,10 @@ pub fn detect_reader_short_eof_still_detects_test() {
   |> should.equal("image/png")
 }
 
-pub fn detect_reader_strict_error_returns_error_nil_test() {
+pub fn detect_reader_strict_error_preserves_reader_error_test() {
   let reader = fn(_limit) { Error("disk read failure") }
   mimetype.detect_reader_strict(reader, 3072)
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(mimetype.ReaderError("disk read failure")))
 }
 
 pub fn detect_reader_error_returns_default_test() {
@@ -1570,11 +1570,11 @@ pub fn detect_reader_strict_ok_test() {
   |> should.equal(Ok("image/png"))
 }
 
-pub fn detect_reader_strict_no_match_returns_error_test() {
+pub fn detect_reader_strict_no_match_returns_no_match_test() {
   let unknown = <<0x00, 0x01, 0x02, 0x03>>
-  let reader = fn(_limit) { Ok(unknown) }
+  let reader: fn(Int) -> Result(BitArray, String) = fn(_limit) { Ok(unknown) }
   mimetype.detect_reader_strict(reader, 3072)
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(mimetype.NoMatch))
 }
 
 pub fn is_a_reflexive_test() {


### PR DESCRIPTION
## Summary

Make \`Reader(read_error)\` generic and introduce \`DetectionError(e)\`
with \`NoMatch\` / \`ReaderError(e)\` variants. \`detect_reader_strict\`
now returns \`Result(String, DetectionError(read_error))\`, so callers
can distinguish a reader failure from a no-match — useful for HTTP
upload pipelines and Lustre file-drop UIs that want to render the
two cases differently. Closes the Reader-bearing portion of #61;
the rest of the strict family stays on \`Result(_, Nil)\` and is
tracked as follow-up.

## Changes

- \`src/mimetype.gleam\`:
  - \`type Reader = fn(Int) -> Result(BitArray, String)\` →
    \`type Reader(read_error) = fn(Int) -> Result(BitArray, read_error)\`.
  - new \`pub type DetectionError(read_error) { NoMatch ; ReaderError(read_error) }\`.
  - \`detect_reader_strict\`'s return type:
    \`Result(String, Nil)\` → \`Result(String, DetectionError(read_error))\`.
  - \`detect_reader\`'s lenient shape is unchanged at the call-site
    (still \`String\`); it now matches \`Error(_)\` instead of
    \`Error(Nil)\` because the inner error type changed.
- \`test/mimetype_test.gleam\`:
  - \`detect_reader_strict_error_returns_error_nil_test\` →
    \`detect_reader_strict_error_preserves_reader_error_test\`,
    asserts \`Error(ReaderError(\"disk read failure\"))\` (the
    reader's own error string is preserved end-to-end).
  - \`detect_reader_strict_no_match_returns_error_test\` →
    \`detect_reader_strict_no_match_returns_no_match_test\`, asserts
    \`Error(NoMatch)\`.
- \`CHANGELOG.md\`: \`### Changed\` entry under \`Unreleased\` with
  BREAKING note + migration hint, plus a \`### Notes\` paragraph
  flagging the rest of #61 as follow-up.

## Design Decisions

- **Two variants now, more later.** \`DetectionError\` only has
  \`NoMatch\` and \`ReaderError(_)\` because that is what the Reader
  path needs; \`UnknownExtension\` / \`EmptyInput\` belong on the
  non-Reader strict functions (\`detect_strict\`,
  \`extension_to_mime_type_strict\`) and adding them now would force
  a wider rewrite and bigger BREAKING surface. Keeping the type
  small and adding variants when the corresponding migration lands
  is cheaper than touching every strict function in one PR.
- **Generic \`Reader(read_error)\` rather than fixed \`Reader(String)\`**.
  \`String\` was a placeholder when streaming was added in 0.3.0
  (#27). JS-side readers (FileReader, ReadableStream) and BEAM-side
  readers (file handles, HTTP clients) carry richer error info
  (DOMException, status codes, posix errnos) — making the type
  parameter explicit lets that flow through unchanged.
- **\`detect_reader/2\` lenient shape unchanged**. Lenient callers
  who want a single \`String\` answer still get one — the only
  observable change is that the inner \`Error(_)\` pattern matches
  \`DetectionError\` instead of \`Nil\`, but lenient code typically
  uses \`Ok(s) -> s ; Error(_) -> default_mime_type\` which is
  unaffected.

## Limitations

- The remaining strict functions in #61's scope (\`detect_strict\`,
  \`extension_to_mime_type_strict\`, \`filename_to_mime_type_strict\`,
  \`detect_with_limit_strict\`, \`detect_signature_only\`,
  \`detect_with_extension_strict\`, \`detect_with_filename_strict\`,
  \`parameter\`, \`charset\`, \`charset_of\`) still return
  \`Result(_, Nil)\`. Migrating those is the larger half of #61 and
  needs additional \`DetectionError\` variants
  (\`UnknownExtension(_)\`, \`EmptyInput\`) plus a sweep of \`~70\`
  test sites — landing it as a separate PR keeps the diff
  reviewable and the BREAKING surface bounded per release.