### PR TITLE
fix(magic): detect OpenDocument zip containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Added
+
+- Detect OpenDocument ZIP containers via their required leading
+  `mimetype` entry: `application/vnd.oasis.opendocument.text`
+  (`.odt`), `application/vnd.oasis.opendocument.spreadsheet`
+  (`.ods`), and `application/vnd.oasis.opendocument.presentation`
+  (`.odp`). This brings content-based detection into line with the
+  existing extension database and ZIP subtype hierarchy.
+
+### Documentation
+
+- README now describes the actual shallow ZIP-container inspection
+  behavior. The previous wording incorrectly implied that ZIP-based
+  Office-family formats were not distinguished at all.
+
 ## [0.7.0] - 2026-04-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ the generated table keeps lookups aligned with that upstream source.
 
 This library intentionally stays focused:
 
-- It does not do deep container introspection such as distinguishing Office formats inside ZIP
+- It does perform shallow ZIP-container inspection for a small fixed allowlist: `epub`, OOXML (`docx`/`xlsx`/`pptx`), OpenDocument (`odt`/`ods`/`odp`), `jar`, and `apk`. It does not recurse arbitrarily into nested containers or inspect embedded subformats beyond those targeted signatures.
 - It does sniff `text/plain` from printable-ASCII-only payloads (the bounded WHATWG-style binary-vs-text heuristic added in #20) and recognises the UTF-8/16/32 BOM signatures, returning `text/plain; charset=<utf-X>` for the BOM cases. This is the **only** text-related sniffing — it does not detect text encodings beyond the BOM marker, and the printable-ASCII fallback emits a bare `text/plain` with no charset parameter.
 - Beyond the four BOM-derived `text/plain; charset=utf-*` signatures it does not parse, validate, or surface MIME-parameter values from the wire.
 
@@ -64,19 +64,20 @@ pub fn main() {
 
 ## Supported magic-number formats
 
-`detect/1` currently recognizes the following MIME types:
+`detect/1` currently recognizes many common MIME types, including:
 
 - Archive and container formats: `application/zip`, `application/gzip`, `application/x-bzip2`, `application/x-xz`, `application/x-7z-compressed`, `application/x-rar-compressed`, `application/vnd.ms-cab-compressed`, `application/x-tar`, `application/zstd`
 - Documents and data formats: `application/pdf`, `application/vnd.sqlite3`, `application/vnd.apache.parquet`
+- ZIP-derived document formats: `application/epub+zip`, `application/vnd.openxmlformats-officedocument.wordprocessingml.document`, `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`, `application/vnd.openxmlformats-officedocument.presentationml.presentation`, `application/vnd.oasis.opendocument.text`, `application/vnd.oasis.opendocument.spreadsheet`, `application/vnd.oasis.opendocument.presentation`, `application/java-archive`, `application/vnd.android.package-archive`
 - Runtime and transport formats: `application/ogg`, `application/wasm`, `application/x-elf`
 - Audio formats: `audio/wav`, `audio/aiff`, `audio/mpeg`, `audio/flac`, `audio/midi`, `audio/mp4`
 - Image formats: `image/png`, `image/jpeg`, `image/gif`, `image/bmp`, `image/tiff`, `image/x-icon`, `image/webp`, `image/avif`, `image/heic`
 - Video formats: `video/x-msvideo`, `video/webm`, `video/quicktime`, `video/mp4`
 
 The detector is intentionally shallow: it looks only at fixed
-signatures near the start of the byte stream. Formats that require
-container introspection, such as Office documents inside ZIP, are not
-currently distinguished.
+signatures near the start of the byte stream, plus a small amount of
+targeted ZIP local-header inspection for the container formats listed
+above. It does not recurse arbitrarily into nested containers.
 
 ## Development
 

--- a/src/mimetype/internal/magic.gleam
+++ b/src/mimetype/internal/magic.gleam
@@ -88,6 +88,9 @@ const signatures = [
     [#(0, <<0xEF, 0xBB, 0xBF, 0x25, 0x50, 0x44, 0x46, 0x2D>>)],
   ),
   Check("application/epub+zip", looks_like_epub),
+  Check("application/vnd.oasis.opendocument.text", looks_like_odt),
+  Check("application/vnd.oasis.opendocument.spreadsheet", looks_like_ods),
+  Check("application/vnd.oasis.opendocument.presentation", looks_like_odp),
   Check(
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     looks_like_docx,
@@ -917,12 +920,42 @@ fn zip_filenames_contain(filenames: List(String), prefix: String) -> Bool {
   list.any(filenames, fn(name) { string.starts_with(name, prefix) })
 }
 
+const zip_stored_mimetype_entry_name = <<"mimetype":utf8>>
+
+fn looks_like_zip_with_stored_mimetype(
+  bytes: BitArray,
+  expected_mime_type: BitArray,
+) -> Bool {
+  use <- bool.guard(when: !has_zip_header(bytes), return: False)
+  let filename_offset = 30
+  let content_offset =
+    filename_offset + bit_array.byte_size(zip_stored_mimetype_entry_name)
+  has_bytes_at(bytes, filename_offset, zip_stored_mimetype_entry_name)
+  && has_bytes_at(bytes, content_offset, expected_mime_type)
+}
+
 fn looks_like_epub(bytes: BitArray) -> Bool {
   // EPUB requires "mimetype" as the first entry, stored uncompressed at
   // offset 30, with content "application/epub+zip".
-  use <- bool.guard(when: !has_zip_header(bytes), return: False)
-  has_bytes_at(bytes, 30, <<"mimetype":utf8>>)
-  && has_bytes_at(bytes, 38, <<"application/epub+zip":utf8>>)
+  looks_like_zip_with_stored_mimetype(bytes, <<"application/epub+zip":utf8>>)
+}
+
+fn looks_like_odt(bytes: BitArray) -> Bool {
+  looks_like_zip_with_stored_mimetype(bytes, <<
+    "application/vnd.oasis.opendocument.text":utf8,
+  >>)
+}
+
+fn looks_like_ods(bytes: BitArray) -> Bool {
+  looks_like_zip_with_stored_mimetype(bytes, <<
+    "application/vnd.oasis.opendocument.spreadsheet":utf8,
+  >>)
+}
+
+fn looks_like_odp(bytes: BitArray) -> Bool {
+  looks_like_zip_with_stored_mimetype(bytes, <<
+    "application/vnd.oasis.opendocument.presentation":utf8,
+  >>)
 }
 
 fn looks_like_jar(bytes: BitArray) -> Bool {

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -18,6 +18,32 @@ fn should_fall_back(bytes) {
   |> should.equal("application/octet-stream")
 }
 
+fn stored_mimetype_zip_archive(mime_type: BitArray) -> BitArray {
+  let mime_type_size = bit_array.byte_size(mime_type)
+
+  bit_array.concat([
+    // Local file header signature
+    <<0x50, 0x4B, 0x03, 0x04>>,
+    // Version needed (2), flags (2), compression=stored (2)
+    <<0x14, 0x00, 0x00, 0x00, 0x00, 0x00>>,
+    // Last mod time (2), last mod date (2)
+    <<0x00, 0x00, 0x00, 0x00>>,
+    // CRC-32 (4)
+    <<0x00, 0x00, 0x00, 0x00>>,
+    // Compressed size = mime_type_size (4, little-endian)
+    <<mime_type_size, 0x00, 0x00, 0x00>>,
+    // Uncompressed size = mime_type_size (4, little-endian)
+    <<mime_type_size, 0x00, 0x00, 0x00>>,
+    // Filename length = 8 (2, little-endian)
+    <<0x08, 0x00>>,
+    // Extra field length = 0 (2)
+    <<0x00, 0x00>>,
+    // Filename: "mimetype"
+    <<"mimetype":utf8>>,
+    mime_type,
+  ])
+}
+
 pub fn extension_to_mime_type_normalizes_input_test() {
   mimetype.extension_to_mime_type(".JSON")
   |> should.equal("application/json")
@@ -331,30 +357,32 @@ pub fn detect_archive_and_compression_formats_test() {
 pub fn detect_epub_test() {
   // EPUB: ZIP with "mimetype" as first entry containing "application/epub+zip"
   // Local file header: PK\x03\x04 + 22 bytes header + filename + data
-  let epub =
-    bit_array.concat([
-      // Local file header signature
-      <<0x50, 0x4B, 0x03, 0x04>>,
-      // Version needed (2), flags (2), compression=stored (2)
-      <<0x14, 0x00, 0x00, 0x00, 0x00, 0x00>>,
-      // Last mod time (2), last mod date (2)
-      <<0x00, 0x00, 0x00, 0x00>>,
-      // CRC-32 (4)
-      <<0x00, 0x00, 0x00, 0x00>>,
-      // Compressed size = 20 (4, little-endian)
-      <<0x14, 0x00, 0x00, 0x00>>,
-      // Uncompressed size = 20 (4, little-endian)
-      <<0x14, 0x00, 0x00, 0x00>>,
-      // Filename length = 8 (2, little-endian)
-      <<0x08, 0x00>>,
-      // Extra field length = 0 (2)
-      <<0x00, 0x00>>,
-      // Filename: "mimetype"
-      <<"mimetype":utf8>>,
-      // File data: "application/epub+zip"
-      <<"application/epub+zip":utf8>>,
-    ])
+  let epub = stored_mimetype_zip_archive(<<"application/epub+zip":utf8>>)
   should_detect(epub, "application/epub+zip")
+}
+
+pub fn detect_odt_test() {
+  let odt =
+    stored_mimetype_zip_archive(<<
+      "application/vnd.oasis.opendocument.text":utf8,
+    >>)
+  should_detect(odt, "application/vnd.oasis.opendocument.text")
+}
+
+pub fn detect_ods_test() {
+  let ods =
+    stored_mimetype_zip_archive(<<
+      "application/vnd.oasis.opendocument.spreadsheet":utf8,
+    >>)
+  should_detect(ods, "application/vnd.oasis.opendocument.spreadsheet")
+}
+
+pub fn detect_odp_test() {
+  let odp =
+    stored_mimetype_zip_archive(<<
+      "application/vnd.oasis.opendocument.presentation":utf8,
+    >>)
+  should_detect(odp, "application/vnd.oasis.opendocument.presentation")
 }
 
 pub fn detect_docx_test() {


### PR DESCRIPTION
## Summary
This PR adds content-based detection for OpenDocument ZIP containers by inspecting the required leading `mimetype` entry. It also aligns the README and changelog with the detector's actual shallow ZIP-container behavior.

## Changes
- detect `application/vnd.oasis.opendocument.text`, `application/vnd.oasis.opendocument.spreadsheet`, and `application/vnd.oasis.opendocument.presentation` from ZIP contents
- factor the stored-`mimetype` ZIP helper used by EPUB and OpenDocument signatures
- add Erlang/JavaScript test coverage for ODT, ODS, and ODP samples
- document the shallow ZIP inspection behavior and record the change in the changelog

## Design Decisions
- reuse the existing shallow ZIP local-header strategy instead of adding deeper container parsing
- keep detection limited to the required first-entry `mimetype` marker for OpenDocument files

## Limitations
- the detector still does not recurse arbitrarily into nested containers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection support for OpenDocument formats (.odt, .ods, .odp).

* **Documentation**
  * Clarified that ZIP-based inspection is shallow and limited to specific container formats.
  * Expanded supported MIME types list to include ZIP-derived document formats.

* **Tests**
  * Added test coverage for OpenDocument file detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->