### PR TITLE
feat(api)!: complete DetectionError migration for strict family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,50 @@
   (`.odp`). This brings content-based detection into line with the
   existing extension database and ZIP subtype hierarchy.
 
+### Changed
+
+- **Strict family (BREAKING)**: the remaining ten strict-family
+  functions (`detect_strict`, `detect_with_limit_strict`,
+  `detect_signature_only`, `detect_signature_only_with_limit`,
+  `detect_with_extension_strict`, `detect_with_filename_strict`,
+  `extension_to_mime_type_strict`, `filename_to_mime_type_strict`,
+  `parameter`, `charset`, `charset_of`) now return
+  `Result(_, DetectionError(Nil))` instead of `Result(_, Nil)`,
+  matching the shape `detect_reader_strict` already used in 0.7.0.
+  `DetectionError` gains two new variants alongside the existing
+  `NoMatch` and `ReaderError(_)`:
+    - `EmptyInput` — the input was a zero-byte `BitArray`, an empty
+      extension string, or a path with no usable extension.
+    - `UnknownExtension(String)` — the supplied filename / extension
+      is not in the MIME database; the normalised lookup key is
+      carried so callers can render it without re-parsing.
+  Migration: callers that pattern-matched `Error(Nil)` switch to
+  matching the relevant variant (often `Error(NoMatch)` for
+  detection failures, `Error(EmptyInput)` for empty inputs, and
+  `Error(UnknownExtension(_))` for the extension-lookup failures of
+  `extension_to_mime_type_strict` / `filename_to_mime_type_strict`).
+  The lenient (`String`-returning) wrappers — `extension_to_mime_type`,
+  `filename_to_mime_type`, `detect`, `detect_with_limit`,
+  `detect_reader`, `detect_with_extension`, `detect_with_filename` —
+  still return a single `String` and behave identically to 0.7.0.
+  `mime_type_to_extensions_strict` is intentionally out of scope for
+  #61 and continues to return `Result(_, Nil)`. Closes the rest of
+  #61. (#61)
+- **`charset_of` (BREAKING, behaviour change)**: now returns
+  `Error(EmptyInput)` for the zero-byte `BitArray`. Previously the
+  internal pure-ASCII fallback caused `charset_of(<<>>)` to return
+  `Ok("us-ascii")`, which was surprising — "no bytes" is not
+  evidence of an encoding. Non-empty inputs whose encoding cannot
+  be determined now return `Error(NoMatch)` (renamed from
+  `Error(Nil)`).
+
 ### Documentation
 
 - README now describes the actual shallow ZIP-container inspection
   behavior. The previous wording incorrectly implied that ZIP-based
   Office-family formats were not distinguished at all.
+- README's `detect_strict(<<>>)` example shows the new
+  `Error(EmptyInput)` shape.
 
 ## [0.7.0] - 2026-04-28
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pub fn main() {
   // -> "application/octet-stream"  (silent fallback for unknown / empty input)
 
   mimetype.detect_strict(<<>>)
-  // -> Error(Nil)  (loud variant — distinguishes "no signature" from a match)
+  // -> Error(EmptyInput)  (loud variant — empty input vs. NoMatch)
 
   mimetype.detect_with_filename(<<0, 1, 2, 3>>, "report.csv")
   // -> "text/csv"

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -41,16 +41,29 @@ pub fn extension_to_mime_type(extension: String) -> String {
   // The generated db module expects already-normalized keys.
   case extension_to_mime_type_strict(extension) {
     Ok(mime_type) -> mime_type
-    Error(Nil) -> default_mime_type
+    Error(NoMatch) -> default_mime_type
+    Error(UnknownExtension(_)) -> default_mime_type
+    Error(EmptyInput) -> default_mime_type
+    Error(ReaderError(_)) -> default_mime_type
   }
 }
 
 /// Look up a MIME type from a file extension.
 ///
-/// This strict variant returns `Error(Nil)` when the normalized
-/// extension is not present in the generated database.
-pub fn extension_to_mime_type_strict(extension: String) -> Result(String, Nil) {
-  db.extension_to_mime_type(normalize_extension(extension))
+/// Returns `Error(EmptyInput)` when the input normalises to the empty
+/// string (e.g. `""`, `"."`, `"   "`). Returns
+/// `Error(UnknownExtension(ext))` when the normalised extension is not
+/// present in the generated database, carrying the lookup key so the
+/// caller can render it without re-parsing.
+pub fn extension_to_mime_type_strict(
+  extension: String,
+) -> Result(String, DetectionError(Nil)) {
+  let normalized = normalize_extension(extension)
+  use <- bool.guard(when: normalized == "", return: Error(EmptyInput))
+  case db.extension_to_mime_type(normalized) {
+    Ok(mime_type) -> Ok(mime_type)
+    Error(Nil) -> Error(UnknownExtension(normalized))
+  }
 }
 
 /// Return all known extensions for a MIME type.
@@ -164,12 +177,20 @@ pub fn is_xml_based(mime: String) -> Bool {
 ///      multi-byte UTF-8 sequences, `us-ascii` for input that is
 ///      entirely 0x00–0x7F.
 ///
-/// Returns `Error(Nil)` for inputs whose encoding cannot be determined
+/// Returns `Error(EmptyInput)` for the zero-byte `BitArray`, and
+/// `Error(NoMatch)` for inputs whose encoding cannot be determined
 /// (typically non-UTF-8 high-byte content like Latin-1 or Shift_JIS
 /// without an in-document declaration). Charset names are returned in
 /// lowercase, matching the convention used by IANA's charset registry.
-pub fn charset_of(bytes: BitArray) -> Result(String, Nil) {
-  charset_internal.detect(bytes)
+pub fn charset_of(bytes: BitArray) -> Result(String, DetectionError(Nil)) {
+  use <- bool.guard(
+    when: bit_array.byte_size(bytes) == 0,
+    return: Error(EmptyInput),
+  )
+  case charset_internal.detect(bytes) {
+    Ok(charset) -> Ok(charset)
+    Error(Nil) -> Error(NoMatch)
+  }
 }
 
 /// Return the chain of ancestors of `mime`, ordered from immediate
@@ -193,27 +214,39 @@ fn ancestors_loop(mime: String, acc: List(String)) -> List(String) {
 
 /// Look up a parameter value from a MIME type string.
 ///
-/// Parameter names are matched case-insensitively. This returns
-/// `Error(Nil)` when the key is empty or the parameter is missing.
-pub fn parameter(mime_type: String, key: String) -> Result(String, Nil) {
+/// Parameter names are matched case-insensitively. Returns
+/// `Error(EmptyInput)` when the key normalises to empty (e.g. `""`,
+/// `"   "`) and `Error(NoMatch)` when the MIME type carries no
+/// parameters or none match the requested key.
+pub fn parameter(
+  mime_type: String,
+  key: String,
+) -> Result(String, DetectionError(Nil)) {
   let requested = key |> string.trim |> string.lowercase
 
-  use <- bool.guard(when: requested == "", return: Error(Nil))
+  use <- bool.guard(when: requested == "", return: Error(EmptyInput))
 
   case string.split(mime_type, ";") {
-    [] -> Error(Nil)
-    [_] -> Error(Nil)
-    [_essence, ..parameters] -> find_parameter(parameters, requested)
+    [] -> Error(NoMatch)
+    [_] -> Error(NoMatch)
+    [_essence, ..parameters] ->
+      case find_parameter(parameters, requested) {
+        Ok(value) -> Ok(value)
+        Error(Nil) -> Error(NoMatch)
+      }
   }
 }
 
 /// Return the `charset` parameter from a MIME type string.
 ///
-/// Charset values are normalized to lowercase for convenience.
-pub fn charset(mime_type: String) -> Result(String, Nil) {
+/// Charset values are normalized to lowercase for convenience. The
+/// underlying `parameter/2` lookup decides between `EmptyInput` (the
+/// internal `"charset"` key never normalises to empty, so this case
+/// does not arise in practice) and `NoMatch` (no `charset=` found).
+pub fn charset(mime_type: String) -> Result(String, DetectionError(Nil)) {
   case parameter(mime_type, "charset") {
     Ok(value) -> Ok(string.lowercase(value))
-    Error(Nil) -> Error(Nil)
+    Error(reason) -> Error(reason)
   }
 }
 
@@ -226,19 +259,26 @@ pub fn charset(mime_type: String) -> Result(String, Nil) {
 pub fn filename_to_mime_type(path: String) -> String {
   case filename_to_mime_type_strict(path) {
     Ok(mime_type) -> mime_type
-    Error(Nil) -> default_mime_type
+    Error(NoMatch) -> default_mime_type
+    Error(UnknownExtension(_)) -> default_mime_type
+    Error(EmptyInput) -> default_mime_type
+    Error(ReaderError(_)) -> default_mime_type
   }
 }
 
 /// Look up a MIME type from the last extension component of a path or
 /// filename.
 ///
-/// This strict variant returns `Error(Nil)` when the path does not
-/// contain a usable extension or the extension is unknown.
-pub fn filename_to_mime_type_strict(path: String) -> Result(String, Nil) {
+/// Returns `Error(EmptyInput)` when the path does not contain a usable
+/// extension (e.g. `"README"`, `".gitignore"`, `""`). Returns
+/// `Error(UnknownExtension(ext))` when the path has an extension but
+/// the normalised extension is not in the database.
+pub fn filename_to_mime_type_strict(
+  path: String,
+) -> Result(String, DetectionError(Nil)) {
   case extension_from_filename(path) {
     Some(extension) -> extension_to_mime_type_strict(extension)
-    None -> Error(Nil)
+    None -> Error(EmptyInput)
   }
 }
 
@@ -264,21 +304,22 @@ pub fn filename_to_mime_type_strict(path: String) -> Result(String, Nil) {
 /// bytes — including the empty `BitArray`. The fallback is silent: a
 /// caller that needs to distinguish "no signature matched" from
 /// "signature matched but produced `application/octet-stream`" should
-/// use `detect_strict/1`, which returns `Error(Nil)` for the
-/// no-match case.
+/// use `detect_strict/1`, which returns `Error(EmptyInput)` for the
+/// zero-byte input and `Error(NoMatch)` for the no-match case.
 pub fn detect(bytes: BitArray) -> String {
   detect_with_limit(bytes, default_detection_limit)
 }
 
 /// Detect a MIME type from the leading bytes of a blob.
 ///
-/// This strict variant returns `Error(Nil)` when no supported
-/// magic-number signature matches the input (including the empty
-/// `BitArray`), so the caller can distinguish "no signature found"
-/// from "signature matched". Prefer this variant when the
-/// `application/octet-stream` fallback would be ambiguous; use
-/// `detect/1` when an unconditional `String` is more convenient.
-pub fn detect_strict(bytes: BitArray) -> Result(String, Nil) {
+/// Returns `Error(EmptyInput)` for the zero-byte `BitArray`, and
+/// `Error(NoMatch)` when no supported magic-number signature matches
+/// non-empty input — letting the caller distinguish "you didn't give
+/// us anything" from "we looked and didn't find a match". Prefer this
+/// variant when the `application/octet-stream` fallback would be
+/// ambiguous; use `detect/1` when an unconditional `String` is more
+/// convenient.
+pub fn detect_strict(bytes: BitArray) -> Result(String, DetectionError(Nil)) {
   detect_with_limit_strict(bytes, default_detection_limit)
 }
 
@@ -291,19 +332,30 @@ pub fn detect_strict(bytes: BitArray) -> Result(String, Nil) {
 pub fn detect_with_limit(bytes: BitArray, limit: Int) -> String {
   case detect_with_limit_strict(bytes, limit) {
     Ok(mime_type) -> mime_type
-    Error(Nil) -> default_mime_type
+    Error(NoMatch) -> default_mime_type
+    Error(UnknownExtension(_)) -> default_mime_type
+    Error(EmptyInput) -> default_mime_type
+    Error(ReaderError(_)) -> default_mime_type
   }
 }
 
 /// Detect a MIME type from at most `limit` leading bytes.
 ///
-/// Strict variant; returns `Error(Nil)` when no supported signature
-/// matches within the limit.
+/// Strict variant; returns `Error(EmptyInput)` for the zero-byte
+/// `BitArray` and `Error(NoMatch)` when no supported signature matches
+/// within the limit.
 pub fn detect_with_limit_strict(
   bytes: BitArray,
   limit: Int,
-) -> Result(String, Nil) {
-  result_from_option(magic.detect(truncate_to_limit(bytes, limit)))
+) -> Result(String, DetectionError(Nil)) {
+  use <- bool.guard(
+    when: bit_array.byte_size(bytes) == 0,
+    return: Error(EmptyInput),
+  )
+  case magic.detect(truncate_to_limit(bytes, limit)) {
+    Some(mime_type) -> Ok(mime_type)
+    None -> Error(NoMatch)
+  }
 }
 
 /// Detect a MIME type from a genuine binary or structural signature
@@ -313,16 +365,19 @@ pub fn detect_with_limit_strict(
 /// otherwise classifies every plain-ASCII payload as `text/plain`.
 /// Returns `Ok(mime_type)` for byte magic numbers (PNG, JPEG, ZIP,
 /// `text/plain; charset=utf-*` BOMs, ...) and structural sniffs that
-/// inspect bytes (JSON, HTML, XML, SVG). Returns `Error(Nil)` for
-/// arbitrary printable-ASCII text — letting the caller defer to a
-/// stronger out-of-band hint such as a filename extension.
+/// inspect bytes (JSON, HTML, XML, SVG). Returns `Error(EmptyInput)`
+/// for the zero-byte `BitArray` and `Error(NoMatch)` for arbitrary
+/// printable-ASCII text — letting the caller defer to a stronger
+/// out-of-band hint such as a filename extension.
 ///
 /// This is the building block behind `detect_with_filename` /
 /// `detect_with_extension`: a `.csv` filename is a stronger signal
 /// than the byte-level fact "this is printable ASCII", so those
 /// helpers consult the filename hint when the only thing the byte
 /// side could say was `text/plain`.
-pub fn detect_signature_only(bytes: BitArray) -> Result(String, Nil) {
+pub fn detect_signature_only(
+  bytes: BitArray,
+) -> Result(String, DetectionError(Nil)) {
   detect_signature_only_with_limit(bytes, default_detection_limit)
 }
 
@@ -330,8 +385,15 @@ pub fn detect_signature_only(bytes: BitArray) -> Result(String, Nil) {
 pub fn detect_signature_only_with_limit(
   bytes: BitArray,
   limit: Int,
-) -> Result(String, Nil) {
-  result_from_option(magic.detect_signature(truncate_to_limit(bytes, limit)))
+) -> Result(String, DetectionError(Nil)) {
+  use <- bool.guard(
+    when: bit_array.byte_size(bytes) == 0,
+    return: Error(EmptyInput),
+  )
+  case magic.detect_signature(truncate_to_limit(bytes, limit)) {
+    Some(mime_type) -> Ok(mime_type)
+    None -> Error(NoMatch)
+  }
 }
 
 fn truncate_to_limit(bytes: BitArray, limit: Int) -> BitArray {
@@ -355,17 +417,30 @@ fn truncate_to_limit(bytes: BitArray, limit: Int) -> BitArray {
 pub type Reader(read_error) =
   fn(Int) -> Result(BitArray, read_error)
 
-/// Reasons `detect_reader_strict` can return `Error(_)`.
+/// Reasons the strict detection family can return `Error(_)`.
 ///
 /// The error is structured so callers can distinguish "no signature
 /// matched" from "the reader itself failed before any bytes could be
-/// inspected" — useful for HTTP upload pipelines that want to render
-/// "couldn't read the file" differently from "we don't recognise this
-/// format". `read_error` is the type the supplied `Reader` produces;
-/// it flows through unchanged when the reader fails.
+/// inspected" from "the supplied filename / extension is not in the
+/// database" from "the input was empty" — useful for HTTP upload
+/// pipelines that want to render each case differently. `read_error`
+/// is the type the supplied `Reader` produces; it flows through
+/// unchanged when the reader fails. Strict functions that do not take
+/// a reader use `DetectionError(Nil)`.
 pub type DetectionError(read_error) {
-  /// No signature matched the bytes that were inspected.
+  /// No signature matched the bytes that were inspected, and no
+  /// filename / extension hint resolved.
   NoMatch
+  /// The supplied filename or extension is not present in the MIME
+  /// database. Carries the normalised extension so callers can render
+  /// "we don't recognise the `.xyz` extension" without re-parsing.
+  UnknownExtension(String)
+  /// The input was empty: a zero-byte `BitArray`, an empty extension
+  /// string, or a filename whose path component carries no usable
+  /// extension. Distinguished from `NoMatch` so callers can render
+  /// "you didn't give us anything to look at" differently from "we
+  /// looked and didn't find a match".
+  EmptyInput
   /// The reader returned an error before any bytes could be inspected.
   ReaderError(read_error)
 }
@@ -379,6 +454,8 @@ pub fn detect_reader(read: Reader(read_error), limit: Int) -> String {
   case detect_reader_strict(read, limit) {
     Ok(mime_type) -> mime_type
     Error(NoMatch) -> default_mime_type
+    Error(UnknownExtension(_)) -> default_mime_type
+    Error(EmptyInput) -> default_mime_type
     Error(ReaderError(_)) -> default_mime_type
   }
 }
@@ -403,7 +480,10 @@ pub fn detect_reader_strict(
     Ok(bytes) ->
       case detect_with_limit_strict(bytes, safe_limit) {
         Ok(mime_type) -> Ok(mime_type)
-        Error(Nil) -> Error(NoMatch)
+        Error(EmptyInput) -> Error(EmptyInput)
+        Error(NoMatch) -> Error(NoMatch)
+        Error(UnknownExtension(extension)) -> Error(UnknownExtension(extension))
+        Error(ReaderError(_)) -> Error(NoMatch)
       }
     Error(read_error) -> Error(ReaderError(read_error))
   }
@@ -423,28 +503,28 @@ pub fn detect_reader_strict(
 pub fn detect_with_extension(bytes: BitArray, extension: String) -> String {
   case detect_with_extension_strict(bytes, extension) {
     Ok(mime_type) -> mime_type
-    Error(Nil) -> default_mime_type
+    Error(NoMatch) -> default_mime_type
+    Error(UnknownExtension(_)) -> default_mime_type
+    Error(EmptyInput) -> default_mime_type
+    Error(ReaderError(_)) -> default_mime_type
   }
 }
 
 /// Detect a MIME type from bytes, consulting an explicit extension
 /// hint when the byte signature alone is not specific enough.
 ///
-/// This strict variant returns `Error(Nil)` only when neither the byte
-/// signature, the normalised extension, nor the printable-ASCII
-/// fallback succeed.
+/// Returns `Error(EmptyInput)` only when both the bytes and the
+/// extension carry no information (zero-byte input *and* an
+/// extension that normalises to empty). Returns `Error(NoMatch)`
+/// when neither the byte signature, the normalised extension, nor
+/// the printable-ASCII fallback succeed.
 pub fn detect_with_extension_strict(
   bytes: BitArray,
   extension: String,
-) -> Result(String, Nil) {
-  case detect_signature_only(bytes) {
-    Ok(mime_type) -> Ok(mime_type)
-    Error(Nil) ->
-      case extension_to_mime_type_strict(extension) {
-        Ok(mime_type) -> Ok(mime_type)
-        Error(Nil) -> detect_strict(bytes)
-      }
-  }
+) -> Result(String, DetectionError(Nil)) {
+  detect_signature_only(bytes)
+  |> result.lazy_or(fn() { extension_to_mime_type_strict(extension) })
+  |> result.lazy_or(fn() { detect_strict(bytes) })
 }
 
 /// Detect a MIME type from bytes, consulting the filename extension
@@ -461,28 +541,27 @@ pub fn detect_with_extension_strict(
 pub fn detect_with_filename(bytes: BitArray, filename: String) -> String {
   case detect_with_filename_strict(bytes, filename) {
     Ok(mime_type) -> mime_type
-    Error(Nil) -> default_mime_type
+    Error(NoMatch) -> default_mime_type
+    Error(UnknownExtension(_)) -> default_mime_type
+    Error(EmptyInput) -> default_mime_type
+    Error(ReaderError(_)) -> default_mime_type
   }
 }
 
 /// Detect a MIME type from bytes, consulting the filename extension
 /// when the byte signature alone is not specific enough.
 ///
-/// This strict variant returns `Error(Nil)` only when neither the byte
-/// signature, the filename extension, nor the printable-ASCII fallback
-/// succeed.
+/// Returns `Error(EmptyInput)` when the bytes are empty and the
+/// filename has no usable extension. Returns `Error(NoMatch)` when
+/// neither the byte signature, the filename extension, nor the
+/// printable-ASCII fallback succeed.
 pub fn detect_with_filename_strict(
   bytes: BitArray,
   filename: String,
-) -> Result(String, Nil) {
-  case detect_signature_only(bytes) {
-    Ok(mime_type) -> Ok(mime_type)
-    Error(Nil) ->
-      case filename_to_mime_type_strict(filename) {
-        Ok(mime_type) -> Ok(mime_type)
-        Error(Nil) -> detect_strict(bytes)
-      }
-  }
+) -> Result(String, DetectionError(Nil)) {
+  detect_signature_only(bytes)
+  |> result.lazy_or(fn() { filename_to_mime_type_strict(filename) })
+  |> result.lazy_or(fn() { detect_strict(bytes) })
 }
 
 fn normalize_extension(extension: String) -> String {
@@ -547,11 +626,4 @@ fn find_parameter(
       _ -> Error(Nil)
     }
   })
-}
-
-fn result_from_option(value: Option(a)) -> Result(a, Nil) {
-  case value {
-    Some(inner) -> Ok(inner)
-    None -> Error(Nil)
-  }
 }

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -81,7 +81,17 @@ pub fn extension_to_mime_type_strict_returns_ok_for_known_extension_test() {
 
 pub fn extension_to_mime_type_strict_returns_error_for_unknown_extension_test() {
   mimetype.extension_to_mime_type_strict("totally-unknown-ext")
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(mimetype.UnknownExtension("totally-unknown-ext")))
+}
+
+pub fn extension_to_mime_type_strict_returns_empty_input_for_blank_test() {
+  mimetype.extension_to_mime_type_strict("")
+  |> should.equal(Error(mimetype.EmptyInput))
+}
+
+pub fn extension_to_mime_type_strict_returns_empty_input_for_dot_only_test() {
+  mimetype.extension_to_mime_type_strict(".")
+  |> should.equal(Error(mimetype.EmptyInput))
 }
 
 pub fn mime_type_to_extensions_returns_all_known_extensions_test() {
@@ -162,9 +172,14 @@ pub fn parameter_matches_case_insensitively_test() {
   |> should.equal(Ok("UTF-8"))
 }
 
-pub fn parameter_returns_error_for_missing_key_test() {
+pub fn parameter_returns_no_match_for_missing_key_test() {
   mimetype.parameter("text/html; charset=UTF-8", "boundary")
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(mimetype.NoMatch))
+}
+
+pub fn parameter_returns_empty_input_for_blank_key_test() {
+  mimetype.parameter("text/html; charset=UTF-8", "")
+  |> should.equal(Error(mimetype.EmptyInput))
 }
 
 pub fn charset_returns_lowercased_value_test() {
@@ -172,9 +187,9 @@ pub fn charset_returns_lowercased_value_test() {
   |> should.equal(Ok("utf-8"))
 }
 
-pub fn charset_returns_error_when_missing_test() {
+pub fn charset_returns_no_match_when_missing_test() {
   mimetype.charset("text/html")
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(mimetype.NoMatch))
 }
 
 pub fn family_predicates_use_essence_test() {
@@ -225,9 +240,14 @@ pub fn filename_to_mime_type_strict_returns_ok_for_known_filename_test() {
   |> should.equal(Ok("application/pdf"))
 }
 
-pub fn filename_to_mime_type_strict_returns_error_without_extension_test() {
+pub fn filename_to_mime_type_strict_returns_empty_input_without_extension_test() {
   mimetype.filename_to_mime_type_strict("README")
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(mimetype.EmptyInput))
+}
+
+pub fn filename_to_mime_type_strict_returns_unknown_extension_test() {
+  mimetype.filename_to_mime_type_strict("notes.totally-unknown-ext")
+  |> should.equal(Error(mimetype.UnknownExtension("totally-unknown-ext")))
 }
 
 pub fn filename_to_mime_type_uses_last_extension_test() {
@@ -326,9 +346,16 @@ pub fn detect_strict_returns_ok_for_known_signature_test() {
   |> should.equal(Ok("image/png"))
 }
 
-pub fn detect_strict_returns_error_for_unknown_signature_test() {
+pub fn detect_strict_returns_empty_input_for_zero_bytes_test() {
   mimetype.detect_strict(<<>>)
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(mimetype.EmptyInput))
+}
+
+pub fn detect_strict_returns_no_match_for_unknown_signature_test() {
+  // Single 0xFF byte — not empty, but no signature matches and the
+  // printable-ASCII fallback rejects it.
+  mimetype.detect_strict(<<0xFF>>)
+  |> should.equal(Error(mimetype.NoMatch))
 }
 
 pub fn detect_archive_and_compression_formats_test() {
@@ -737,9 +764,9 @@ pub fn detect_with_extension_strict_falls_back_to_extension_test() {
   |> should.equal(Ok("text/csv"))
 }
 
-pub fn detect_with_extension_strict_returns_error_when_both_are_unknown_test() {
+pub fn detect_with_extension_strict_returns_no_match_when_both_are_unknown_test() {
   mimetype.detect_with_extension_strict(<<1, 2, 3, 4>>, "totally-unknown-ext")
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(mimetype.NoMatch))
 }
 
 pub fn detect_with_extension_normalizes_leading_dot_and_case_test() {
@@ -762,9 +789,9 @@ pub fn detect_with_filename_strict_falls_back_to_filename_test() {
   |> should.equal(Ok("text/csv"))
 }
 
-pub fn detect_with_filename_strict_returns_error_when_both_are_unknown_test() {
+pub fn detect_with_filename_strict_returns_no_match_when_both_are_unknown_test() {
   mimetype.detect_with_filename_strict(<<1, 2, 3, 4>>, "README")
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(mimetype.NoMatch))
 }
 
 pub fn detect_with_filename_prefers_magic_over_extension_test() {
@@ -832,21 +859,21 @@ pub fn detect_signature_only_returns_ok_for_bom_tagged_text_test() {
   |> should.equal(Ok("text/plain; charset=utf-8"))
 }
 
-pub fn detect_signature_only_returns_error_for_printable_ascii_test() {
+pub fn detect_signature_only_returns_no_match_for_printable_ascii_test() {
   // The whole point of this helper: plain printable ASCII is *not*
   // a signature match here.
   mimetype.detect_signature_only(<<"plain text\n":utf8>>)
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(mimetype.NoMatch))
 }
 
-pub fn detect_signature_only_returns_error_for_empty_test() {
+pub fn detect_signature_only_returns_empty_input_for_empty_test() {
   mimetype.detect_signature_only(<<>>)
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(mimetype.EmptyInput))
 }
 
-pub fn detect_signature_only_returns_error_for_unknown_binary_test() {
+pub fn detect_signature_only_returns_no_match_for_unknown_binary_test() {
   mimetype.detect_signature_only(<<1, 2, 3, 4>>)
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(mimetype.NoMatch))
 }
 
 pub fn detect_json_empty_object_test() {
@@ -1538,10 +1565,10 @@ pub fn detect_with_limit_strict_returns_ok_test() {
   |> should.equal(Ok("image/png"))
 }
 
-pub fn detect_with_limit_strict_returns_error_when_below_offset_test() {
+pub fn detect_with_limit_strict_returns_no_match_when_below_offset_test() {
   let bytes = <<0:size({ 257 * 8 }), 0x75, 0x73, 0x74, 0x61, 0x72, 0:size(64)>>
   mimetype.detect_with_limit_strict(bytes, 100)
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(mimetype.NoMatch))
 }
 
 pub fn detect_reader_returns_same_as_detect_test() {
@@ -1762,18 +1789,22 @@ pub fn charset_of_html_with_utf8_body_no_meta_test() {
   |> should.equal(Ok("utf-8"))
 }
 
-pub fn charset_of_invalid_utf8_returns_error_test() {
+pub fn charset_of_invalid_utf8_returns_no_match_test() {
   // 0xC0 0x20 — invalid UTF-8 (0xC0 is an over-long encoding lead byte that
   // cannot be followed by 0x20 in valid UTF-8).
   mimetype.charset_of(<<0x48, 0x69, 0xC0, 0x20>>)
-  |> should.equal(Error(Nil))
+  |> should.equal(Error(mimetype.NoMatch))
+}
+
+pub fn charset_of_empty_returns_empty_input_test() {
+  mimetype.charset_of(<<>>)
+  |> should.equal(Error(mimetype.EmptyInput))
 }
 
 pub fn charset_of_truncated_meta_does_not_false_positive_test() {
-  // <meta charset="u — incomplete attribute, no closing quote. Returns
-  // Error(Nil) because the quoted-value reader can't find the closing
-  // quote and the UTF-8 fallback also rejects the high-byte-free input.
-  // Actually all-ASCII input falls through to us-ascii.
+  // <meta charset="u — incomplete attribute, no closing quote. The
+  // quoted-value reader can't find the closing quote, but all-ASCII
+  // input still falls through to us-ascii via the UTF-8 fallback.
   mimetype.charset_of(<<"<meta charset=\"u":utf8>>)
   |> should.equal(Ok("us-ascii"))
 }
@@ -1796,11 +1827,4 @@ pub fn charset_of_utf32_le_bom_test() {
 pub fn charset_of_utf32_be_bom_test() {
   mimetype.charset_of(<<0x00, 0x00, 0xFE, 0xFF, 0x00, 0x00, 0x00, 0x48>>)
   |> should.equal(Ok("utf-32be"))
-}
-
-pub fn charset_of_empty_returns_pure_ascii_test() {
-  // Empty bytes → PureAscii (no multi-byte seen). Caller can treat this
-  // as "no content" if they prefer.
-  mimetype.charset_of(<<>>)
-  |> should.equal(Ok("us-ascii"))
 }


### PR DESCRIPTION
## Summary

Complete the `DetectionError` migration started in #63. The remaining
ten strict-family functions now return
`Result(_, DetectionError(Nil))` instead of `Result(_, Nil)`, so
callers can distinguish empty input, no-match, and unknown-extension
cases without re-running the lookup. Closes #61.

## Changes

- `src/mimetype.gleam`:
  - `DetectionError(read_error)` gains `EmptyInput` and
    `UnknownExtension(String)` variants alongside the existing
    `NoMatch` and `ReaderError(_)`. Strict functions that do not take
    a reader use `DetectionError(Nil)`.
  - Migrated functions: `detect_strict`, `detect_with_limit_strict`,
    `detect_signature_only`, `detect_signature_only_with_limit`,
    `detect_with_extension_strict`, `detect_with_filename_strict`,
    `extension_to_mime_type_strict`, `filename_to_mime_type_strict`,
    `parameter`, `charset`, `charset_of`. All now return
    `Result(String, DetectionError(Nil))`.
  - Lenient wrappers (`extension_to_mime_type`, `filename_to_mime_type`,
    `detect_with_limit`, `detect_reader`, `detect_with_extension`,
    `detect_with_filename`) still return `String` and behave
    identically; they just exhaustively match the new variants
    instead of `Error(Nil)`.
  - `detect_with_extension_strict` and `detect_with_filename_strict`
    fall back through the signature/extension/printable-ASCII chain
    via `result.lazy_or` rather than nested `case` expressions.
  - Removed the now-unused `result_from_option` helper.
- `test/mimetype_test.gleam`: 13 `Error(Nil)` assertions migrated to
  the appropriate `DetectionError` variant; added explicit
  `EmptyInput` / `UnknownExtension` coverage for
  `extension_to_mime_type_strict`, `filename_to_mime_type_strict`,
  `parameter`, `detect_strict`, `detect_signature_only`, and
  `charset_of`. Replaced the old "empty `charset_of` returns
  us-ascii" assertion with the new `EmptyInput` shape.
- `CHANGELOG.md`: BREAKING entry under `Unreleased` describing the
  strict-family migration, the new variants, the migration steps,
  and the `charset_of(<<>>)` behaviour change.
- `README.md`: usage example updated from `Error(Nil)` to
  `Error(EmptyInput)` to match the new shape.

## Design Decisions

- **Single break, no `_v2` aliases.** Issue #61 explicitly favoured
  one clean rename over a deprecation cycle for an 0.x package with
  no external consumers, and PR #63 already half-completed the
  break — adding aliases now would just leave the API in two
  inconsistent halves.
- **`EmptyInput` as a first-class variant.** Empty input (zero-byte
  `BitArray`, empty extension string, filename with no usable
  extension) is qualitatively different from "we looked and found
  no match". Callers writing upload pipelines or file-drop UIs can
  legitimately want to render the cases differently — "you didn't
  give us anything" vs. "we couldn't recognise this".
- **`UnknownExtension(String)` carries the lookup key.** Without it,
  a caller rendering "we don't recognise the `.xyz` extension"
  would have to re-derive the normalised extension from the
  original input — exactly the kind of duplication this PR is
  meant to remove.
- **`charset_of(<<>>)` now returns `Error(EmptyInput)`.** Previously
  the internal pure-ASCII fallback meant `charset_of(<<>>)` returned
  `Ok("us-ascii")`. "No bytes" is not evidence of an encoding, so
  the new shape is more honest and the fallback is preserved for
  any non-empty all-ASCII input.
- **Lenient wrappers exhaustively match new variants.** Writing
  `Error(_) -> default_mime_type` would tripped glinter's
  `thrown_away_error` rule (the new variants carry payload, unlike
  the old `Nil`). Each lenient case lists every variant explicitly,
  matching the pattern PR #63 established for `detect_reader`.
- **Internal chains use `result.lazy_or`.** `detect_with_extension_strict`
  and `detect_with_filename_strict` previously nested three `case`
  expressions to fall back through the signature → metadata →
  printable-ASCII chain. `result.lazy_or` expresses the same chain
  as a pipe, preserves laziness (each fallback only evaluates if
  the prior step actually failed), and avoids the `Error(_) ->`
  shape that would have tripped the linter.

## Limitations

- `mime_type_to_extensions_strict` is intentionally out of scope —
  Issue #61 only covers the strict family that mirrors the
  detection / parameter / charset surface. Migrating
  `mime_type_to_extensions_strict` is a separate question (the
  failure case is "MIME type not in DB", which would want its own
  `UnknownMimeType(String)` variant) and would land as a follow-up
  if there's demand.
- The opaque `MimeType` type discussion (Issue #62) is independent
  of this PR; nothing here precludes that direction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Strict MIME detection functions now return more specific error types: `EmptyInput` for empty/unusable inputs, `UnknownExtension` for unrecognized file extensions, and `NoMatch` for unidentifiable signatures.
  * Charset detection now returns `EmptyInput` error for empty input instead of a fallback value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->