### PR TITLE
feat(api)!: introduce opaque MimeType type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,66 @@
   (`.ods`), and `application/vnd.oasis.opendocument.presentation`
   (`.odp`). This brings content-based detection into line with the
   existing extension database and ZIP subtype hierarchy.
+- **`pub opaque type MimeType`**: a normalised, validated MIME type
+  value carrying both the essence (`type/subtype`) and the parsed
+  parameter list. All detection / lookup helpers now return
+  `MimeType` (or `Result(MimeType, _)`); predicates and accessors
+  operate on `MimeType` rather than ad-hoc strings. Construction:
+    - `parse(String) -> Result(MimeType, ParseError)` — wire-format
+      parser. Returns `Error(EmptyMimeType)` for empty input and
+      `Error(InvalidMimeType(original))` for malformed essences.
+    - `to_string(MimeType) -> String` — serialise back to the
+      wire format (round-trippable through `parse`).
+  Accessors:
+    - `essence_of(MimeType) -> String`
+    - `parameter_of(MimeType, String) -> Option(String)`
+    - `charset_of_type(MimeType) -> Option(String)`
+- **`ParseError`** type, with `EmptyMimeType` and
+  `InvalidMimeType(String)` variants, returned by `parse/1`.
 
 ### Changed
 
-- **Strict family (BREAKING)**: the remaining ten strict-family
-  functions (`detect_strict`, `detect_with_limit_strict`,
+- **API-wide `String` → `MimeType` (BREAKING)**: every detection
+  and lookup function now returns `MimeType` (or
+  `Result(MimeType, DetectionError(_))`) instead of a bare
+  `String`. Predicates and ancestor helpers take `MimeType`.
+  Affected functions:
+    - `detect`, `detect_strict`
+    - `detect_with_limit`, `detect_with_limit_strict`
+    - `detect_signature_only`, `detect_signature_only_with_limit`
+    - `detect_with_extension`, `detect_with_extension_strict`
+    - `detect_with_filename`, `detect_with_filename_strict`
+    - `detect_reader`, `detect_reader_strict`
+    - `extension_to_mime_type`, `extension_to_mime_type_strict`
+    - `filename_to_mime_type`, `filename_to_mime_type_strict`
+    - `mime_type_to_extensions`, `mime_type_to_extensions_strict`
+      (argument changes from `String` to `MimeType`; return list
+      stays `List(String)`)
+    - `is_image`, `is_text`, `is_audio`, `is_video`
+    - `is_a` (both arguments), `is_zip_based`, `is_xml_based`
+    - `ancestors` (argument and list element type both `MimeType`)
+  `default_mime_type` is now a `MimeType` constant rather than a
+  `String`. Migration:
+    - Reading: pipe results through `to_string` (for the wire
+      form) or `essence_of` (for `type/subtype`). Predicates
+      compose directly on the new value, no extraction needed.
+    - Constructing arguments: replace bare strings with
+      `parse(s)` (and `result.unwrap` / `let assert` if you
+      know the input is well-formed). For
+      `mime_type_to_extensions`, that's the most common
+      migration site.
+  `charset_of(BitArray)` continues to return
+  `Result(String, DetectionError(Nil))` — its result is a charset
+  name, not a MIME type. Closes #62. (#62)
+- **Strict family (BREAKING)**: the ten strict-family functions
+  (`detect_strict`, `detect_with_limit_strict`,
   `detect_signature_only`, `detect_signature_only_with_limit`,
   `detect_with_extension_strict`, `detect_with_filename_strict`,
   `extension_to_mime_type_strict`, `filename_to_mime_type_strict`,
-  `parameter`, `charset`, `charset_of`) now return
-  `Result(_, DetectionError(Nil))` instead of `Result(_, Nil)`,
-  matching the shape `detect_reader_strict` already used in 0.7.0.
-  `DetectionError` gains two new variants alongside the existing
-  `NoMatch` and `ReaderError(_)`:
+  `charset_of`) now return `Result(_, DetectionError(Nil))` instead
+  of `Result(_, Nil)`, matching the shape `detect_reader_strict`
+  already used in 0.7.0. `DetectionError` gains two new variants
+  alongside the existing `NoMatch` and `ReaderError(_)`:
     - `EmptyInput` — the input was a zero-byte `BitArray`, an empty
       extension string, or a path with no usable extension.
     - `UnknownExtension(String)` — the supplied filename / extension
@@ -33,13 +80,7 @@
   detection failures, `Error(EmptyInput)` for empty inputs, and
   `Error(UnknownExtension(_))` for the extension-lookup failures of
   `extension_to_mime_type_strict` / `filename_to_mime_type_strict`).
-  The lenient (`String`-returning) wrappers — `extension_to_mime_type`,
-  `filename_to_mime_type`, `detect`, `detect_with_limit`,
-  `detect_reader`, `detect_with_extension`, `detect_with_filename` —
-  still return a single `String` and behave identically to 0.7.0.
-  `mime_type_to_extensions_strict` is intentionally out of scope for
-  #61 and continues to return `Result(_, Nil)`. Closes the rest of
-  #61. (#61)
+  Closes the rest of #61. (#61)
 - **`charset_of` (BREAKING, behaviour change)**: now returns
   `Error(EmptyInput)` for the zero-byte `BitArray`. Previously the
   internal pure-ASCII fallback caused `charset_of(<<>>)` to return
@@ -48,6 +89,19 @@
   be determined now return `Error(NoMatch)` (renamed from
   `Error(Nil)`).
 
+### Removed
+
+- **`essence(String) -> String` (BREAKING)** — replaced by
+  `essence_of(MimeType) -> String`. Migration: parse the string
+  first via `parse/1`, then call `essence_of` on the result.
+- **`parameter(String, String) -> Result(String, _)` (BREAKING)** —
+  replaced by `parameter_of(MimeType, String) -> Option(String)`.
+  The error shape collapses from `DetectionError` to `Option`
+  because `parse/1` now front-loads the validation.
+- **`charset(String) -> Result(String, _)` (BREAKING)** — replaced
+  by `charset_of_type(MimeType) -> Option(String)`. Same migration
+  as `parameter`.
+
 ### Documentation
 
 - README now describes the actual shallow ZIP-container inspection
@@ -55,6 +109,9 @@
   Office-family formats were not distinguished at all.
 - README's `detect_strict(<<>>)` example shows the new
   `Error(EmptyInput)` shape.
+- README usage block rewritten to show the `MimeType` workflow:
+  `to_string` for serialisation, `parse` for construction,
+  `essence_of` / `is_image` / `charset_of_type` for inspection.
 
 ## [0.7.0] - 2026-04-28
 

--- a/README.md
+++ b/README.md
@@ -35,30 +35,47 @@ This library intentionally stays focused:
 
 ## Usage
 
+Detection / lookup helpers return an opaque `MimeType` value. Use
+`mimetype.to_string` to serialise one for an HTTP `Content-Type`
+header; use `mimetype.parse` to construct one from a wire-format
+string. Inspect with `essence_of`, `parameter_of`, `charset_of_type`,
+`is_image`, `is_a`, and the rest of the predicate / accessor family.
+
 ```gleam
+import gleam/option.{Some}
 import mimetype
 
 pub fn main() {
   mimetype.extension_to_mime_type(".json")
+  |> mimetype.to_string
   // -> "application/json"
 
-  mimetype.mime_type_to_extensions("image/jpeg")
+  let assert Ok(jpeg) = mimetype.parse("image/jpeg")
+  mimetype.mime_type_to_extensions(jpeg)
   // -> ["jpg", "jpeg", "jpe"]
 
   mimetype.filename_to_mime_type("photo.JPG")
+  |> mimetype.to_string
   // -> "image/jpeg"
 
   mimetype.detect(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>)
-  // -> "image/png"
+  |> mimetype.is_image
+  // -> True
 
   mimetype.detect(<<>>)
+  |> mimetype.to_string
   // -> "application/octet-stream"  (silent fallback for unknown / empty input)
 
   mimetype.detect_strict(<<>>)
   // -> Error(EmptyInput)  (loud variant — empty input vs. NoMatch)
 
   mimetype.detect_with_filename(<<0, 1, 2, 3>>, "report.csv")
+  |> mimetype.essence_of
   // -> "text/csv"
+
+  let assert Ok(html) = mimetype.parse("text/html; charset=utf-8")
+  mimetype.charset_of_type(html)
+  // -> Some("utf-8")
 }
 ```
 

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -1,6 +1,13 @@
 //// MIME type lookup and byte-signature detection for Gleam.
 ////
-//// The public API intentionally separates:
+//// The public API is built around the opaque `MimeType` value: every
+//// detection / lookup function returns a `MimeType` (or
+//// `Result(MimeType, _)`), and predicates / accessors operate on
+//// `MimeType` rather than ad-hoc strings. Use `parse/1` to construct a
+//// `MimeType` from a wire-format string and `to_string/1` to serialise
+//// one back out (e.g. for an HTTP `Content-Type` header).
+////
+//// The library intentionally separates:
 //// - extension / filename lookup, which is cheap and deterministic
 //// - magic-number detection, which inspects the leading bytes
 //// - combined helpers, which prefer content-based detection and fall
@@ -17,405 +24,27 @@ import mimetype/internal/db
 import mimetype/internal/hierarchy
 import mimetype/internal/magic
 
-/// Fallback MIME type used when neither metadata nor byte signatures
-/// provide a more specific answer.
-pub const default_mime_type = db.default_mime_type
-
-/// Default upper bound on the number of leading bytes inspected by
-/// `detect` and `detect_strict`.
+/// A normalised, validated MIME type.
 ///
-/// 3072 bytes is large enough for every signature this library ships
-/// (the largest fixed-offset check is `application/x-tar` at offset
-/// 257, plus envelope formats like ZIP central-directory inspection
-/// reach into the first few KB) and matches the default used by Go's
-/// `gabriel-vasile/mimetype` library. Pass an explicit limit via
-/// `detect_with_limit` / `detect_with_limit_strict` to override.
-pub const default_detection_limit = 3072
-
-/// Look up a MIME type from a file extension.
-///
-/// The input may include a leading dot and is normalized to lowercase
-/// before lookup. Unknown extensions fall back to
-/// `application/octet-stream`.
-pub fn extension_to_mime_type(extension: String) -> String {
-  // The generated db module expects already-normalized keys.
-  case extension_to_mime_type_strict(extension) {
-    Ok(mime_type) -> mime_type
-    Error(NoMatch) -> default_mime_type
-    Error(UnknownExtension(_)) -> default_mime_type
-    Error(EmptyInput) -> default_mime_type
-    Error(ReaderError(_)) -> default_mime_type
-  }
+/// Construct one with `parse/1` (from a wire-format string), or via the
+/// detection / lookup helpers (`detect/1`, `extension_to_mime_type/1`,
+/// `filename_to_mime_type/1`, ...). Inspect with `essence_of/1`,
+/// `parameter_of/2`, `charset_of_type/1`, `is_image/1`, `is_a/2`, and
+/// the rest of the predicate / accessor family. Serialise back to a
+/// string with `to_string/1`.
+pub opaque type MimeType {
+  MimeType(essence: String, parameters: List(#(String, String)))
 }
 
-/// Look up a MIME type from a file extension.
-///
-/// Returns `Error(EmptyInput)` when the input normalises to the empty
-/// string (e.g. `""`, `"."`, `"   "`). Returns
-/// `Error(UnknownExtension(ext))` when the normalised extension is not
-/// present in the generated database, carrying the lookup key so the
-/// caller can render it without re-parsing.
-pub fn extension_to_mime_type_strict(
-  extension: String,
-) -> Result(String, DetectionError(Nil)) {
-  let normalized = normalize_extension(extension)
-  use <- bool.guard(when: normalized == "", return: Error(EmptyInput))
-  case db.extension_to_mime_type(normalized) {
-    Ok(mime_type) -> Ok(mime_type)
-    Error(Nil) -> Error(UnknownExtension(normalized))
-  }
+/// Why `parse/1` rejected a string.
+pub type ParseError {
+  /// The input was empty or contained only whitespace.
+  EmptyMimeType
+  /// The input did not match the `type/subtype` essence shape required
+  /// by RFC 6838. The original input is carried so the caller can
+  /// render it without re-parsing.
+  InvalidMimeType(String)
 }
-
-/// Return all known extensions for a MIME type.
-///
-/// The input is trimmed, lowercased, and stripped of any MIME
-/// parameters (such as `; charset=utf-8`) before lookup. Unknown MIME
-/// types return the empty list.
-pub fn mime_type_to_extensions(mime_type: String) -> List(String) {
-  // The generated db module expects already-normalized keys.
-  case mime_type_to_extensions_strict(mime_type) {
-    Ok(extensions) -> extensions
-    Error(Nil) -> []
-  }
-}
-
-/// Return all known extensions for a MIME type.
-///
-/// This strict variant returns `Error(Nil)` when the normalized MIME
-/// type is not present in the generated database.
-pub fn mime_type_to_extensions_strict(
-  mime_type: String,
-) -> Result(List(String), Nil) {
-  mime_type |> essence |> db.mime_type_to_extensions
-}
-
-/// Return the bare MIME type without any parameters.
-///
-/// This trims surrounding whitespace, lowercases the media type, and
-/// strips anything after the first `;`.
-pub fn essence(mime_type: String) -> String {
-  mime_type
-  |> string.trim
-  |> string.lowercase
-  |> split_head(on: ";")
-  |> string.trim
-}
-
-/// Return `True` when the MIME type's top-level media type is `image`.
-pub fn is_image(mime_type: String) -> Bool {
-  string.starts_with(essence(mime_type), "image/")
-}
-
-/// Return `True` when the MIME type's top-level media type is `text`.
-pub fn is_text(mime_type: String) -> Bool {
-  string.starts_with(essence(mime_type), "text/")
-}
-
-/// Return `True` when the MIME type's top-level media type is `audio`.
-pub fn is_audio(mime_type: String) -> Bool {
-  string.starts_with(essence(mime_type), "audio/")
-}
-
-/// Return `True` when the MIME type's top-level media type is `video`.
-pub fn is_video(mime_type: String) -> Bool {
-  string.starts_with(essence(mime_type), "video/")
-}
-
-/// Return `True` when `mime` is `parent` or transitively inherits from
-/// `parent` in the static subtype tree.
-///
-/// The relation is reflexive (`is_a(x, x)` is always `True` for any
-/// non-empty `x`) and transitive (if `a` inherits from `b` and `b`
-/// inherits from `c`, then `is_a(a, c)` is `True`).
-///
-/// Both arguments are normalized via `essence` so parameters and case
-/// differences are ignored.
-pub fn is_a(mime: String, parent: String) -> Bool {
-  let mime_essence = essence(mime)
-  let parent_essence = essence(parent)
-  use <- bool.guard(when: mime_essence == "", return: False)
-  use <- bool.guard(when: parent_essence == "", return: False)
-  is_a_loop(mime_essence, parent_essence)
-}
-
-fn is_a_loop(mime: String, parent: String) -> Bool {
-  use <- bool.lazy_guard(when: mime == parent, return: fn() { True })
-  case hierarchy.parent_of(mime) {
-    Ok(next) -> is_a_loop(next, parent)
-    Error(Nil) -> False
-  }
-}
-
-/// Return `True` when `mime` is, or inherits from, `application/zip`.
-///
-/// Convenience wrapper for `is_a(mime, "application/zip")`. Returns
-/// `True` for `.docx` / `.xlsx` / `.epub` / `.apk` and other ZIP-based
-/// container formats.
-pub fn is_zip_based(mime: String) -> Bool {
-  is_a(mime, "application/zip")
-}
-
-/// Return `True` when `mime` is, or inherits from, an XML media type.
-///
-/// Both `text/xml` and `application/xml` are accepted as XML roots, in
-/// line with RFC 7303 which permits both. Returns `True` for
-/// `image/svg+xml` and any other `*+xml` types added to the hierarchy.
-pub fn is_xml_based(mime: String) -> Bool {
-  is_a(mime, "text/xml") || is_a(mime, "application/xml")
-}
-
-/// Detect the character encoding (charset) of a `BitArray`.
-///
-/// Returns `Ok(charset)` when one of the following signals fires
-/// (in priority order):
-///
-///   1. A Unicode BOM (UTF-8 / UTF-16 LE/BE / UTF-32 LE/BE).
-///   2. An XML prolog `<?xml ... encoding="..." ?>`.
-///   3. An HTML `<meta charset="...">` (or `<meta http-equiv=... content=...>`)
-///      tag in the first 1 KB.
-///   4. A UTF-8 validity scan: `utf-8` for input that contains valid
-///      multi-byte UTF-8 sequences, `us-ascii` for input that is
-///      entirely 0x00–0x7F.
-///
-/// Returns `Error(EmptyInput)` for the zero-byte `BitArray`, and
-/// `Error(NoMatch)` for inputs whose encoding cannot be determined
-/// (typically non-UTF-8 high-byte content like Latin-1 or Shift_JIS
-/// without an in-document declaration). Charset names are returned in
-/// lowercase, matching the convention used by IANA's charset registry.
-pub fn charset_of(bytes: BitArray) -> Result(String, DetectionError(Nil)) {
-  use <- bool.guard(
-    when: bit_array.byte_size(bytes) == 0,
-    return: Error(EmptyInput),
-  )
-  case charset_internal.detect(bytes) {
-    Ok(charset) -> Ok(charset)
-    Error(Nil) -> Error(NoMatch)
-  }
-}
-
-/// Return the chain of ancestors of `mime`, ordered from immediate
-/// parent to root.
-///
-/// Empty input or roots return `[]`. The returned list does not include
-/// `mime` itself; use `is_a(mime, mime)` (always `True`) if you need
-/// reflexive membership.
-pub fn ancestors(mime: String) -> List(String) {
-  let mime_essence = essence(mime)
-  use <- bool.guard(when: mime_essence == "", return: [])
-  ancestors_loop(mime_essence, [])
-}
-
-fn ancestors_loop(mime: String, acc: List(String)) -> List(String) {
-  case hierarchy.parent_of(mime) {
-    Ok(parent) -> ancestors_loop(parent, [parent, ..acc])
-    Error(Nil) -> list.reverse(acc)
-  }
-}
-
-/// Look up a parameter value from a MIME type string.
-///
-/// Parameter names are matched case-insensitively. Returns
-/// `Error(EmptyInput)` when the key normalises to empty (e.g. `""`,
-/// `"   "`) and `Error(NoMatch)` when the MIME type carries no
-/// parameters or none match the requested key.
-pub fn parameter(
-  mime_type: String,
-  key: String,
-) -> Result(String, DetectionError(Nil)) {
-  let requested = key |> string.trim |> string.lowercase
-
-  use <- bool.guard(when: requested == "", return: Error(EmptyInput))
-
-  case string.split(mime_type, ";") {
-    [] -> Error(NoMatch)
-    [_] -> Error(NoMatch)
-    [_essence, ..parameters] ->
-      case find_parameter(parameters, requested) {
-        Ok(value) -> Ok(value)
-        Error(Nil) -> Error(NoMatch)
-      }
-  }
-}
-
-/// Return the `charset` parameter from a MIME type string.
-///
-/// Charset values are normalized to lowercase for convenience. The
-/// underlying `parameter/2` lookup decides between `EmptyInput` (the
-/// internal `"charset"` key never normalises to empty, so this case
-/// does not arise in practice) and `NoMatch` (no `charset=` found).
-pub fn charset(mime_type: String) -> Result(String, DetectionError(Nil)) {
-  case parameter(mime_type, "charset") {
-    Ok(value) -> Ok(string.lowercase(value))
-    Error(reason) -> Error(reason)
-  }
-}
-
-/// Look up a MIME type from the last extension component of a path or
-/// filename.
-///
-/// Query strings and URL fragments are ignored. Hidden files without a
-/// real extension, such as `.gitignore`, fall back to
-/// `application/octet-stream`.
-pub fn filename_to_mime_type(path: String) -> String {
-  case filename_to_mime_type_strict(path) {
-    Ok(mime_type) -> mime_type
-    Error(NoMatch) -> default_mime_type
-    Error(UnknownExtension(_)) -> default_mime_type
-    Error(EmptyInput) -> default_mime_type
-    Error(ReaderError(_)) -> default_mime_type
-  }
-}
-
-/// Look up a MIME type from the last extension component of a path or
-/// filename.
-///
-/// Returns `Error(EmptyInput)` when the path does not contain a usable
-/// extension (e.g. `"README"`, `".gitignore"`, `""`). Returns
-/// `Error(UnknownExtension(ext))` when the path has an extension but
-/// the normalised extension is not in the database.
-pub fn filename_to_mime_type_strict(
-  path: String,
-) -> Result(String, DetectionError(Nil)) {
-  case extension_from_filename(path) {
-    Some(extension) -> extension_to_mime_type_strict(extension)
-    None -> Error(EmptyInput)
-  }
-}
-
-/// Detect a MIME type from the leading bytes of a blob.
-///
-/// This checks a curated set of common magic-number signatures.
-/// Currently supported MIME types are:
-/// `application/pdf`, `application/zip`, `application/gzip`,
-/// `application/x-bzip2`, `application/x-xz`,
-/// `application/x-7z-compressed`, `application/x-rar-compressed`,
-/// `application/vnd.ms-cab-compressed`, `application/x-tar`,
-/// `application/zstd`, `application/vnd.sqlite3`,
-/// `application/vnd.apache.parquet`, `application/ogg`,
-/// `application/wasm`, `application/x-elf`, `audio/wav`,
-/// `audio/aiff`, `audio/mpeg`, `audio/flac`, `audio/midi`,
-/// `audio/mp4`, `image/png`, `image/jpeg`, `image/gif`,
-/// `image/bmp`, `image/tiff`, `image/x-icon`, `image/webp`,
-/// `image/avif`, `image/heic`, `video/x-msvideo`, `video/webm`,
-/// `video/quicktime`, and `video/mp4`.
-///
-/// Returns `"application/octet-stream"` (the value of
-/// `default_mime_type`) when the input carries no recognisable magic
-/// bytes — including the empty `BitArray`. The fallback is silent: a
-/// caller that needs to distinguish "no signature matched" from
-/// "signature matched but produced `application/octet-stream`" should
-/// use `detect_strict/1`, which returns `Error(EmptyInput)` for the
-/// zero-byte input and `Error(NoMatch)` for the no-match case.
-pub fn detect(bytes: BitArray) -> String {
-  detect_with_limit(bytes, default_detection_limit)
-}
-
-/// Detect a MIME type from the leading bytes of a blob.
-///
-/// Returns `Error(EmptyInput)` for the zero-byte `BitArray`, and
-/// `Error(NoMatch)` when no supported magic-number signature matches
-/// non-empty input — letting the caller distinguish "you didn't give
-/// us anything" from "we looked and didn't find a match". Prefer this
-/// variant when the `application/octet-stream` fallback would be
-/// ambiguous; use `detect/1` when an unconditional `String` is more
-/// convenient.
-pub fn detect_strict(bytes: BitArray) -> Result(String, DetectionError(Nil)) {
-  detect_with_limit_strict(bytes, default_detection_limit)
-}
-
-/// Detect a MIME type from the leading bytes of a blob, examining at
-/// most `limit` bytes from the start of the input.
-///
-/// A non-positive `limit` is treated as zero, in which case no
-/// signature can match and the fallback MIME type is returned.
-/// Limits larger than the input are clamped to the input length.
-pub fn detect_with_limit(bytes: BitArray, limit: Int) -> String {
-  case detect_with_limit_strict(bytes, limit) {
-    Ok(mime_type) -> mime_type
-    Error(NoMatch) -> default_mime_type
-    Error(UnknownExtension(_)) -> default_mime_type
-    Error(EmptyInput) -> default_mime_type
-    Error(ReaderError(_)) -> default_mime_type
-  }
-}
-
-/// Detect a MIME type from at most `limit` leading bytes.
-///
-/// Strict variant; returns `Error(EmptyInput)` for the zero-byte
-/// `BitArray` and `Error(NoMatch)` when no supported signature matches
-/// within the limit.
-pub fn detect_with_limit_strict(
-  bytes: BitArray,
-  limit: Int,
-) -> Result(String, DetectionError(Nil)) {
-  use <- bool.guard(
-    when: bit_array.byte_size(bytes) == 0,
-    return: Error(EmptyInput),
-  )
-  case magic.detect(truncate_to_limit(bytes, limit)) {
-    Some(mime_type) -> Ok(mime_type)
-    None -> Error(NoMatch)
-  }
-}
-
-/// Detect a MIME type from a genuine binary or structural signature
-/// only.
-///
-/// Like `detect_strict` but excludes the printable-ASCII heuristic that
-/// otherwise classifies every plain-ASCII payload as `text/plain`.
-/// Returns `Ok(mime_type)` for byte magic numbers (PNG, JPEG, ZIP,
-/// `text/plain; charset=utf-*` BOMs, ...) and structural sniffs that
-/// inspect bytes (JSON, HTML, XML, SVG). Returns `Error(EmptyInput)`
-/// for the zero-byte `BitArray` and `Error(NoMatch)` for arbitrary
-/// printable-ASCII text — letting the caller defer to a stronger
-/// out-of-band hint such as a filename extension.
-///
-/// This is the building block behind `detect_with_filename` /
-/// `detect_with_extension`: a `.csv` filename is a stronger signal
-/// than the byte-level fact "this is printable ASCII", so those
-/// helpers consult the filename hint when the only thing the byte
-/// side could say was `text/plain`.
-pub fn detect_signature_only(
-  bytes: BitArray,
-) -> Result(String, DetectionError(Nil)) {
-  detect_signature_only_with_limit(bytes, default_detection_limit)
-}
-
-/// `detect_signature_only` with an explicit byte budget.
-pub fn detect_signature_only_with_limit(
-  bytes: BitArray,
-  limit: Int,
-) -> Result(String, DetectionError(Nil)) {
-  use <- bool.guard(
-    when: bit_array.byte_size(bytes) == 0,
-    return: Error(EmptyInput),
-  )
-  case magic.detect_signature(truncate_to_limit(bytes, limit)) {
-    Some(mime_type) -> Ok(mime_type)
-    None -> Error(NoMatch)
-  }
-}
-
-fn truncate_to_limit(bytes: BitArray, limit: Int) -> BitArray {
-  let size = bit_array.byte_size(bytes)
-  let safe_limit = case limit < 0, limit > size {
-    True, _ -> 0
-    False, True -> size
-    False, False -> limit
-  }
-  bit_array.slice(bytes, 0, safe_limit) |> result.unwrap(<<>>)
-}
-
-/// A callback that reads up to the requested number of bytes from an
-/// input source. Returns `Ok(bits)` with the bytes actually read, or
-/// `Error(reason)` if the read fails. A reader that returns fewer bytes
-/// than requested signals end-of-input.
-///
-/// The error type is generic so JS-side readers (FileReader,
-/// ReadableStream) and BEAM-side readers (file handles, HTTP clients)
-/// can preserve their richer error shapes through `detect_reader_strict`.
-pub type Reader(read_error) =
-  fn(Int) -> Result(BitArray, read_error)
 
 /// Reasons the strict detection family can return `Error(_)`.
 ///
@@ -445,14 +74,245 @@ pub type DetectionError(read_error) {
   ReaderError(read_error)
 }
 
-/// Detect a MIME type by pulling at most `limit` leading bytes through
-/// a caller-supplied reader.
+/// A callback that reads up to the requested number of bytes from an
+/// input source. Returns `Ok(bits)` with the bytes actually read, or
+/// `Error(reason)` if the read fails. A reader that returns fewer bytes
+/// than requested signals end-of-input.
 ///
-/// The reader is called once with `limit` as the requested byte count.
-/// If the reader returns an error, the default MIME type is returned.
-pub fn detect_reader(read: Reader(read_error), limit: Int) -> String {
-  case detect_reader_strict(read, limit) {
-    Ok(mime_type) -> mime_type
+/// The error type is generic so JS-side readers (FileReader,
+/// ReadableStream) and BEAM-side readers (file handles, HTTP clients)
+/// can preserve their richer error shapes through `detect_reader_strict`.
+pub type Reader(read_error) =
+  fn(Int) -> Result(BitArray, read_error)
+
+/// Fallback `MimeType` returned by lenient detection / lookup helpers
+/// when no more specific answer is available. Equivalent to
+/// `application/octet-stream` with no parameters.
+pub const default_mime_type: MimeType = MimeType(
+  essence: "application/octet-stream",
+  parameters: [],
+)
+
+/// Default upper bound on the number of leading bytes inspected by
+/// `detect` and `detect_strict`.
+///
+/// 3072 bytes is large enough for every signature this library ships
+/// (the largest fixed-offset check is `application/x-tar` at offset
+/// 257, plus envelope formats like ZIP central-directory inspection
+/// reach into the first few KB) and matches the default used by Go's
+/// `gabriel-vasile/mimetype` library. Pass an explicit limit via
+/// `detect_with_limit` / `detect_with_limit_strict` to override.
+pub const default_detection_limit = 3072
+
+// ---------------------------------------------------------------------------
+// Construction and serialisation
+// ---------------------------------------------------------------------------
+
+/// Parse a MIME type string into a `MimeType` value.
+///
+/// The essence (`type/subtype`) is trimmed and lowercased, and any
+/// `; key=value` parameters are parsed and stored on the value so
+/// later accessors don't have to re-parse. Returns
+/// `Error(EmptyMimeType)` for empty / whitespace-only input and
+/// `Error(InvalidMimeType(original))` when the essence does not have
+/// the `type/subtype` shape required by RFC 6838.
+pub fn parse(input: String) -> Result(MimeType, ParseError) {
+  let trimmed = string.trim(input)
+  use <- bool.guard(when: trimmed == "", return: Error(EmptyMimeType))
+  case string.split(trimmed, on: ";") {
+    [] -> Error(EmptyMimeType)
+    [head, ..rest] -> {
+      let essence_value = head |> string.trim |> string.lowercase
+      use <- bool.guard(
+        when: !valid_essence(essence_value),
+        return: Error(InvalidMimeType(input)),
+      )
+      Ok(MimeType(essence: essence_value, parameters: parse_parameters(rest)))
+    }
+  }
+}
+
+/// Serialise a `MimeType` back to its wire-format string. The output
+/// always normalises whitespace ("`type/subtype; key=value`" with a
+/// single space after each semicolon) and is round-trippable through
+/// `parse/1`.
+pub fn to_string(mt: MimeType) -> String {
+  let MimeType(essence_value, parameters) = mt
+  case parameters {
+    [] -> essence_value
+    _ -> {
+      let serialised_parameters =
+        parameters
+        |> list.map(fn(p) {
+          let #(k, v) = p
+          k <> "=" <> v
+        })
+        |> string.join("; ")
+      essence_value <> "; " <> serialised_parameters
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Accessors
+// ---------------------------------------------------------------------------
+
+/// Return the bare essence (`type/subtype`) of a `MimeType`, with all
+/// parameters stripped. The result is already trimmed and lowercased.
+pub fn essence_of(mt: MimeType) -> String {
+  let MimeType(essence_value, _) = mt
+  essence_value
+}
+
+/// Look up a parameter value on a `MimeType`. Returns `None` for
+/// missing parameters and for an empty / whitespace-only `key`.
+/// Parameter names are matched case-insensitively; values are
+/// returned with surrounding whitespace stripped but case preserved.
+pub fn parameter_of(mt: MimeType, key: String) -> Option(String) {
+  let requested = key |> string.trim |> string.lowercase
+  use <- bool.lazy_guard(when: requested == "", return: fn() { None })
+  let MimeType(_, parameters) = mt
+  parameters
+  |> list.find_map(fn(p) {
+    let #(name, value) = p
+    case name == requested {
+      True -> Ok(value)
+      False -> Error(Nil)
+    }
+  })
+  |> option.from_result
+}
+
+/// Return the `charset` parameter from a `MimeType` (lowercased), if
+/// present. Equivalent to `parameter_of(mt, "charset")` followed by
+/// `string.lowercase`.
+pub fn charset_of_type(mt: MimeType) -> Option(String) {
+  case parameter_of(mt, "charset") {
+    Some(value) -> Some(string.lowercase(value))
+    None -> None
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Family predicates
+// ---------------------------------------------------------------------------
+
+/// Return `True` when the MIME type's top-level media type is `image`.
+pub fn is_image(mt: MimeType) -> Bool {
+  string.starts_with(essence_of(mt), "image/")
+}
+
+/// Return `True` when the MIME type's top-level media type is `text`.
+pub fn is_text(mt: MimeType) -> Bool {
+  string.starts_with(essence_of(mt), "text/")
+}
+
+/// Return `True` when the MIME type's top-level media type is `audio`.
+pub fn is_audio(mt: MimeType) -> Bool {
+  string.starts_with(essence_of(mt), "audio/")
+}
+
+/// Return `True` when the MIME type's top-level media type is `video`.
+pub fn is_video(mt: MimeType) -> Bool {
+  string.starts_with(essence_of(mt), "video/")
+}
+
+/// Return `True` when `mime` is `parent` or transitively inherits from
+/// `parent` in the static subtype tree.
+///
+/// The relation is reflexive (`is_a(x, x)` is always `True` for any
+/// non-empty `x`) and transitive (if `a` inherits from `b` and `b`
+/// inherits from `c`, then `is_a(a, c)` is `True`).
+pub fn is_a(mime: MimeType, parent: MimeType) -> Bool {
+  let mime_essence = essence_of(mime)
+  let parent_essence = essence_of(parent)
+  use <- bool.guard(when: mime_essence == "", return: False)
+  use <- bool.guard(when: parent_essence == "", return: False)
+  is_a_loop(mime_essence, parent_essence)
+}
+
+/// Return `True` when `mime` is, or inherits from, `application/zip`.
+///
+/// Convenience wrapper for `is_a(mime, parse("application/zip"))`.
+/// Returns `True` for `.docx` / `.xlsx` / `.epub` / `.apk` and other
+/// ZIP-based container formats.
+pub fn is_zip_based(mime: MimeType) -> Bool {
+  is_a_loop(essence_of(mime), "application/zip")
+}
+
+/// Return `True` when `mime` is, or inherits from, an XML media type.
+///
+/// Both `text/xml` and `application/xml` are accepted as XML roots,
+/// in line with RFC 7303 which permits both. Returns `True` for
+/// `image/svg+xml` and any other `*+xml` types added to the hierarchy.
+pub fn is_xml_based(mime: MimeType) -> Bool {
+  let mime_essence = essence_of(mime)
+  is_a_loop(mime_essence, "text/xml")
+  || is_a_loop(mime_essence, "application/xml")
+}
+
+/// Return the chain of ancestors of `mime`, ordered from immediate
+/// parent to root.
+///
+/// Empty input or roots return `[]`. The returned list does not
+/// include `mime` itself; use `is_a(mime, mime)` (always `True`) if
+/// you need reflexive membership.
+pub fn ancestors(mime: MimeType) -> List(MimeType) {
+  let mime_essence = essence_of(mime)
+  use <- bool.guard(when: mime_essence == "", return: [])
+  ancestors_loop(mime_essence, [])
+}
+
+// ---------------------------------------------------------------------------
+// Charset detection from raw bytes
+// ---------------------------------------------------------------------------
+
+/// Detect the character encoding (charset) of a `BitArray`.
+///
+/// Returns `Ok(charset)` when one of the following signals fires
+/// (in priority order):
+///
+///   1. A Unicode BOM (UTF-8 / UTF-16 LE/BE / UTF-32 LE/BE).
+///   2. An XML prolog `<?xml ... encoding="..." ?>`.
+///   3. An HTML `<meta charset="...">` (or `<meta http-equiv=... content=...>`)
+///      tag in the first 1 KB.
+///   4. A UTF-8 validity scan: `utf-8` for input that contains valid
+///      multi-byte UTF-8 sequences, `us-ascii` for input that is
+///      entirely 0x00–0x7F.
+///
+/// Returns `Error(EmptyInput)` for the zero-byte `BitArray`, and
+/// `Error(NoMatch)` for inputs whose encoding cannot be determined
+/// (typically non-UTF-8 high-byte content like Latin-1 or Shift_JIS
+/// without an in-document declaration). Charset names are returned in
+/// lowercase, matching the convention used by IANA's charset registry.
+///
+/// The result is a charset name (e.g. `"utf-8"`), not a `MimeType`,
+/// because the caller typically pairs it with a separately determined
+/// media type via `parameter_of` / `charset_of_type` rather than as a
+/// standalone MIME value.
+pub fn charset_of(bytes: BitArray) -> Result(String, DetectionError(Nil)) {
+  use <- bool.guard(
+    when: bit_array.byte_size(bytes) == 0,
+    return: Error(EmptyInput),
+  )
+  case charset_internal.detect(bytes) {
+    Ok(charset) -> Ok(charset)
+    Error(Nil) -> Error(NoMatch)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lookup: extension → MIME
+// ---------------------------------------------------------------------------
+
+/// Look up a `MimeType` from a file extension.
+///
+/// The input may include a leading dot and is normalised to lowercase
+/// before lookup. Unknown / empty inputs fall back to
+/// `default_mime_type`.
+pub fn extension_to_mime_type(extension: String) -> MimeType {
+  case extension_to_mime_type_strict(extension) {
+    Ok(mt) -> mt
     Error(NoMatch) -> default_mime_type
     Error(UnknownExtension(_)) -> default_mime_type
     Error(EmptyInput) -> default_mime_type
@@ -460,18 +320,205 @@ pub fn detect_reader(read: Reader(read_error), limit: Int) -> String {
   }
 }
 
-/// Detect a MIME type by pulling at most `limit` leading bytes through
-/// a caller-supplied reader.
+/// Look up a `MimeType` from a file extension.
+///
+/// Returns `Error(EmptyInput)` when the input normalises to the empty
+/// string (e.g. `""`, `"."`, `"   "`). Returns
+/// `Error(UnknownExtension(ext))` when the normalised extension is
+/// not present in the generated database, carrying the lookup key so
+/// the caller can render it without re-parsing.
+pub fn extension_to_mime_type_strict(
+  extension: String,
+) -> Result(MimeType, DetectionError(Nil)) {
+  let normalized = normalize_extension(extension)
+  use <- bool.guard(when: normalized == "", return: Error(EmptyInput))
+  case db.extension_to_mime_type(normalized) {
+    Ok(s) -> Ok(from_internal(s))
+    Error(Nil) -> Error(UnknownExtension(normalized))
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lookup: MIME → extensions
+// ---------------------------------------------------------------------------
+
+/// Return all known extensions for a `MimeType`. Unknown MIME types
+/// return the empty list.
+pub fn mime_type_to_extensions(mt: MimeType) -> List(String) {
+  case mime_type_to_extensions_strict(mt) {
+    Ok(extensions) -> extensions
+    Error(Nil) -> []
+  }
+}
+
+/// Return all known extensions for a `MimeType`.
+///
+/// Strict variant; returns `Error(Nil)` when the essence is not in the
+/// generated database.
+pub fn mime_type_to_extensions_strict(mt: MimeType) -> Result(List(String), Nil) {
+  db.mime_type_to_extensions(essence_of(mt))
+}
+
+// ---------------------------------------------------------------------------
+// Lookup: filename → MIME
+// ---------------------------------------------------------------------------
+
+/// Look up a `MimeType` from the last extension component of a path
+/// or filename.
+///
+/// Query strings and URL fragments are ignored. Hidden files without
+/// a real extension, such as `.gitignore`, fall back to
+/// `default_mime_type`.
+pub fn filename_to_mime_type(path: String) -> MimeType {
+  case filename_to_mime_type_strict(path) {
+    Ok(mt) -> mt
+    Error(NoMatch) -> default_mime_type
+    Error(UnknownExtension(_)) -> default_mime_type
+    Error(EmptyInput) -> default_mime_type
+    Error(ReaderError(_)) -> default_mime_type
+  }
+}
+
+/// Look up a `MimeType` from the last extension component of a path
+/// or filename.
+///
+/// Returns `Error(EmptyInput)` when the path does not contain a
+/// usable extension (e.g. `"README"`, `".gitignore"`, `""`). Returns
+/// `Error(UnknownExtension(ext))` when the path has an extension but
+/// the normalised extension is not in the database.
+pub fn filename_to_mime_type_strict(
+  path: String,
+) -> Result(MimeType, DetectionError(Nil)) {
+  case extension_from_filename(path) {
+    Some(extension) -> extension_to_mime_type_strict(extension)
+    None -> Error(EmptyInput)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Detection: bytes → MIME
+// ---------------------------------------------------------------------------
+
+/// Detect a `MimeType` from the leading bytes of a blob.
+///
+/// Returns `default_mime_type` (`application/octet-stream`) when the
+/// input carries no recognisable magic bytes — including the empty
+/// `BitArray`. The fallback is silent: a caller that needs to
+/// distinguish "no signature matched" from "signature matched but
+/// produced `application/octet-stream`" should use `detect_strict/1`,
+/// which returns `Error(EmptyInput)` for the zero-byte input and
+/// `Error(NoMatch)` for the no-match case.
+pub fn detect(bytes: BitArray) -> MimeType {
+  detect_with_limit(bytes, default_detection_limit)
+}
+
+/// Detect a `MimeType` from the leading bytes of a blob.
+///
+/// Returns `Error(EmptyInput)` for the zero-byte `BitArray`, and
+/// `Error(NoMatch)` when no supported magic-number signature matches
+/// non-empty input. Prefer this variant when the
+/// `application/octet-stream` fallback would be ambiguous; use
+/// `detect/1` when an unconditional `MimeType` is more convenient.
+pub fn detect_strict(bytes: BitArray) -> Result(MimeType, DetectionError(Nil)) {
+  detect_with_limit_strict(bytes, default_detection_limit)
+}
+
+/// Detect a `MimeType` from the leading bytes of a blob, examining
+/// at most `limit` bytes from the start of the input.
+///
+/// A non-positive `limit` is treated as zero, in which case no
+/// signature can match and `default_mime_type` is returned. Limits
+/// larger than the input are clamped to the input length.
+pub fn detect_with_limit(bytes: BitArray, limit: Int) -> MimeType {
+  case detect_with_limit_strict(bytes, limit) {
+    Ok(mt) -> mt
+    Error(NoMatch) -> default_mime_type
+    Error(UnknownExtension(_)) -> default_mime_type
+    Error(EmptyInput) -> default_mime_type
+    Error(ReaderError(_)) -> default_mime_type
+  }
+}
+
+/// Detect a `MimeType` from at most `limit` leading bytes.
+///
+/// Strict variant; returns `Error(EmptyInput)` for the zero-byte
+/// `BitArray` and `Error(NoMatch)` when no supported signature
+/// matches within the limit.
+pub fn detect_with_limit_strict(
+  bytes: BitArray,
+  limit: Int,
+) -> Result(MimeType, DetectionError(Nil)) {
+  use <- bool.guard(
+    when: bit_array.byte_size(bytes) == 0,
+    return: Error(EmptyInput),
+  )
+  case magic.detect(truncate_to_limit(bytes, limit)) {
+    Some(s) -> Ok(from_internal(s))
+    None -> Error(NoMatch)
+  }
+}
+
+/// Detect a `MimeType` from a genuine binary or structural signature
+/// only.
+///
+/// Like `detect_strict` but excludes the printable-ASCII heuristic
+/// that otherwise classifies every plain-ASCII payload as
+/// `text/plain`. Returns `Ok(mime_type)` for byte magic numbers (PNG,
+/// JPEG, ZIP, `text/plain; charset=utf-*` BOMs, ...) and structural
+/// sniffs that inspect bytes (JSON, HTML, XML, SVG). Returns
+/// `Error(EmptyInput)` for the zero-byte `BitArray` and
+/// `Error(NoMatch)` for arbitrary printable-ASCII text — letting the
+/// caller defer to a stronger out-of-band hint such as a filename
+/// extension.
+pub fn detect_signature_only(
+  bytes: BitArray,
+) -> Result(MimeType, DetectionError(Nil)) {
+  detect_signature_only_with_limit(bytes, default_detection_limit)
+}
+
+/// `detect_signature_only` with an explicit byte budget.
+pub fn detect_signature_only_with_limit(
+  bytes: BitArray,
+  limit: Int,
+) -> Result(MimeType, DetectionError(Nil)) {
+  use <- bool.guard(
+    when: bit_array.byte_size(bytes) == 0,
+    return: Error(EmptyInput),
+  )
+  case magic.detect_signature(truncate_to_limit(bytes, limit)) {
+    Some(s) -> Ok(from_internal(s))
+    None -> Error(NoMatch)
+  }
+}
+
+/// Detect a `MimeType` by pulling at most `limit` leading bytes
+/// through a caller-supplied reader.
+///
+/// The reader is called once with `limit` as the requested byte
+/// count. If the reader returns an error, `default_mime_type` is
+/// returned.
+pub fn detect_reader(read: Reader(read_error), limit: Int) -> MimeType {
+  case detect_reader_strict(read, limit) {
+    Ok(mt) -> mt
+    Error(NoMatch) -> default_mime_type
+    Error(UnknownExtension(_)) -> default_mime_type
+    Error(EmptyInput) -> default_mime_type
+    Error(ReaderError(_)) -> default_mime_type
+  }
+}
+
+/// Detect a `MimeType` by pulling at most `limit` leading bytes
+/// through a caller-supplied reader.
 ///
 /// Returns `Error(ReaderError(e))` when the reader itself failed, or
 /// `Error(NoMatch)` when the reader produced bytes but no supported
-/// magic-number signature matched within them. The reader's own error
-/// type flows through `ReaderError(_)` unchanged so callers can render
-/// it however they wish.
+/// magic-number signature matched within them. The reader's own
+/// error type flows through `ReaderError(_)` unchanged so callers
+/// can render it however they wish.
 pub fn detect_reader_strict(
   read: Reader(read_error),
   limit: Int,
-) -> Result(String, DetectionError(read_error)) {
+) -> Result(MimeType, DetectionError(read_error)) {
   let safe_limit = case limit < 1 {
     True -> 0
     False -> limit
@@ -479,30 +526,32 @@ pub fn detect_reader_strict(
   case read(safe_limit) {
     Ok(bytes) ->
       case detect_with_limit_strict(bytes, safe_limit) {
-        Ok(mime_type) -> Ok(mime_type)
+        Ok(mt) -> Ok(mt)
         Error(EmptyInput) -> Error(EmptyInput)
         Error(NoMatch) -> Error(NoMatch)
         Error(UnknownExtension(extension)) -> Error(UnknownExtension(extension))
+        // Unreachable: detect_with_limit_strict never produces ReaderError.
         Error(ReaderError(_)) -> Error(NoMatch)
       }
     Error(read_error) -> Error(ReaderError(read_error))
   }
 }
 
-/// Detect a MIME type from bytes, consulting an explicit extension
+/// Detect a `MimeType` from bytes, consulting an explicit extension
 /// hint when the byte signature alone is not specific enough.
 ///
-/// Genuine binary signatures (PNG, JPEG, ZIP, BOM-tagged text, ...) and
-/// structural sniffs (JSON, HTML, XML, SVG) win over the extension
-/// hint. The extension takes priority when the only thing the byte
-/// side could say was the printable-ASCII fallback `text/plain` — a
-/// `.csv` extension is a stronger signal for plain-ASCII payloads than
-/// the byte-level fact "this looks textish". The printable-ASCII
-/// fallback is still used as a last resort when neither the byte
-/// signature nor the extension is recognisable.
-pub fn detect_with_extension(bytes: BitArray, extension: String) -> String {
+/// Genuine binary signatures (PNG, JPEG, ZIP, BOM-tagged text, ...)
+/// and structural sniffs (JSON, HTML, XML, SVG) win over the
+/// extension hint. The extension takes priority when the only thing
+/// the byte side could say was the printable-ASCII fallback
+/// `text/plain` — a `.csv` extension is a stronger signal for
+/// plain-ASCII payloads than the byte-level fact "this looks
+/// textish". The printable-ASCII fallback is still used as a last
+/// resort when neither the byte signature nor the extension is
+/// recognisable.
+pub fn detect_with_extension(bytes: BitArray, extension: String) -> MimeType {
   case detect_with_extension_strict(bytes, extension) {
-    Ok(mime_type) -> mime_type
+    Ok(mt) -> mt
     Error(NoMatch) -> default_mime_type
     Error(UnknownExtension(_)) -> default_mime_type
     Error(EmptyInput) -> default_mime_type
@@ -510,7 +559,7 @@ pub fn detect_with_extension(bytes: BitArray, extension: String) -> String {
   }
 }
 
-/// Detect a MIME type from bytes, consulting an explicit extension
+/// Detect a `MimeType` from bytes, consulting an explicit extension
 /// hint when the byte signature alone is not specific enough.
 ///
 /// Returns `Error(EmptyInput)` only when both the bytes and the
@@ -521,26 +570,27 @@ pub fn detect_with_extension(bytes: BitArray, extension: String) -> String {
 pub fn detect_with_extension_strict(
   bytes: BitArray,
   extension: String,
-) -> Result(String, DetectionError(Nil)) {
+) -> Result(MimeType, DetectionError(Nil)) {
   detect_signature_only(bytes)
   |> result.lazy_or(fn() { extension_to_mime_type_strict(extension) })
   |> result.lazy_or(fn() { detect_strict(bytes) })
 }
 
-/// Detect a MIME type from bytes, consulting the filename extension
+/// Detect a `MimeType` from bytes, consulting the filename extension
 /// when the byte signature alone is not specific enough.
 ///
-/// Genuine binary signatures (PNG, JPEG, ZIP, BOM-tagged text, ...) and
-/// structural sniffs (JSON, HTML, XML, SVG) win over the filename. The
-/// filename takes priority when the only thing the byte side could say
-/// was the printable-ASCII fallback `text/plain` — a `report.csv`
-/// filename is a stronger signal for plain-ASCII payloads than the
-/// byte-level fact "this looks textish". The printable-ASCII fallback
-/// is still used as a last resort when neither the byte signature nor
-/// the filename's extension is recognisable.
-pub fn detect_with_filename(bytes: BitArray, filename: String) -> String {
+/// Genuine binary signatures (PNG, JPEG, ZIP, BOM-tagged text, ...)
+/// and structural sniffs (JSON, HTML, XML, SVG) win over the
+/// filename. The filename takes priority when the only thing the
+/// byte side could say was the printable-ASCII fallback `text/plain`
+/// — a `report.csv` filename is a stronger signal for plain-ASCII
+/// payloads than the byte-level fact "this looks textish". The
+/// printable-ASCII fallback is still used as a last resort when
+/// neither the byte signature nor the filename's extension is
+/// recognisable.
+pub fn detect_with_filename(bytes: BitArray, filename: String) -> MimeType {
   case detect_with_filename_strict(bytes, filename) {
-    Ok(mime_type) -> mime_type
+    Ok(mt) -> mt
     Error(NoMatch) -> default_mime_type
     Error(UnknownExtension(_)) -> default_mime_type
     Error(EmptyInput) -> default_mime_type
@@ -548,7 +598,7 @@ pub fn detect_with_filename(bytes: BitArray, filename: String) -> String {
   }
 }
 
-/// Detect a MIME type from bytes, consulting the filename extension
+/// Detect a `MimeType` from bytes, consulting the filename extension
 /// when the byte signature alone is not specific enough.
 ///
 /// Returns `Error(EmptyInput)` when the bytes are empty and the
@@ -558,10 +608,86 @@ pub fn detect_with_filename(bytes: BitArray, filename: String) -> String {
 pub fn detect_with_filename_strict(
   bytes: BitArray,
   filename: String,
-) -> Result(String, DetectionError(Nil)) {
+) -> Result(MimeType, DetectionError(Nil)) {
   detect_signature_only(bytes)
   |> result.lazy_or(fn() { filename_to_mime_type_strict(filename) })
   |> result.lazy_or(fn() { detect_strict(bytes) })
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn valid_essence(essence: String) -> Bool {
+  case string.split_once(essence, on: "/") {
+    Ok(#(t, sub)) -> t != "" && sub != "" && !string.contains(sub, "/")
+    Error(Nil) -> False
+  }
+}
+
+fn parse_parameters(segments: List(String)) -> List(#(String, String)) {
+  segments
+  |> list.filter_map(fn(seg) {
+    case string.split_once(seg, on: "=") {
+      Ok(#(name, value)) -> {
+        let normalized_name = name |> string.trim |> string.lowercase
+        let trimmed_value = string.trim(value)
+        case normalized_name {
+          "" -> Error(Nil)
+          _ -> Ok(#(normalized_name, trimmed_value))
+        }
+      }
+      Error(Nil) -> Error(Nil)
+    }
+  })
+}
+
+/// Build a `MimeType` from a string produced by an internal source
+/// (the magic table, the extension DB, ...) that is expected to be
+/// well-formed. Falls back to a single-essence record if `parse/1`
+/// rejects the input — this should only happen if the data tables
+/// drift, in which case returning a `MimeType` with the raw essence
+/// is more useful than panicking at a detection site.
+fn from_internal(s: String) -> MimeType {
+  case parse(s) {
+    Ok(mt) -> mt
+    Error(EmptyMimeType) ->
+      MimeType(essence: s |> string.trim |> string.lowercase, parameters: [])
+    Error(InvalidMimeType(_)) ->
+      MimeType(essence: s |> string.trim |> string.lowercase, parameters: [])
+  }
+}
+
+/// Build a `MimeType` carrying just an essence (no parameters). Used
+/// by `ancestors` to rebuild parent values from the static hierarchy
+/// table, which only stores essences.
+fn from_essence(essence_value: String) -> MimeType {
+  MimeType(essence: essence_value, parameters: [])
+}
+
+fn is_a_loop(mime: String, parent: String) -> Bool {
+  use <- bool.lazy_guard(when: mime == parent, return: fn() { True })
+  case hierarchy.parent_of(mime) {
+    Ok(next) -> is_a_loop(next, parent)
+    Error(Nil) -> False
+  }
+}
+
+fn ancestors_loop(mime: String, acc: List(MimeType)) -> List(MimeType) {
+  case hierarchy.parent_of(mime) {
+    Ok(parent) -> ancestors_loop(parent, [from_essence(parent), ..acc])
+    Error(Nil) -> list.reverse(acc)
+  }
+}
+
+fn truncate_to_limit(bytes: BitArray, limit: Int) -> BitArray {
+  let size = bit_array.byte_size(bytes)
+  let safe_limit = case limit < 0, limit > size {
+    True, _ -> 0
+    False, True -> size
+    False, False -> limit
+  }
+  bit_array.slice(bytes, 0, safe_limit) |> result.unwrap(<<>>)
 }
 
 fn normalize_extension(extension: String) -> String {
@@ -604,26 +730,4 @@ fn split_head(value: String, on marker: String) -> String {
     Ok(#(head, _)) -> head
     Error(Nil) -> value
   }
-}
-
-fn find_parameter(
-  parameters: List(String),
-  requested: String,
-) -> Result(String, Nil) {
-  parameters
-  |> list.find_map(fn(parameter_segment) {
-    case string.split_once(parameter_segment, "=") {
-      Ok(#(name, value)) -> {
-        let normalized_name = name |> string.trim |> string.lowercase
-
-        use <- bool.guard(
-          when: normalized_name == requested,
-          return: Ok(string.trim(value)),
-        )
-
-        Error(Nil)
-      }
-      _ -> Error(Nil)
-    }
-  })
 }

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -1,5 +1,7 @@
 import gleam/bit_array
 import gleam/list
+import gleam/option.{None, Some}
+import gleam/result
 import gleeunit
 import gleeunit/should
 import mimetype
@@ -8,14 +10,33 @@ pub fn main() -> Nil {
   gleeunit.main()
 }
 
+fn mt(s: String) -> mimetype.MimeType {
+  let assert Ok(value) = mimetype.parse(s)
+  value
+}
+
 fn should_detect(bytes, mime_type) {
   mimetype.detect(bytes)
+  |> mimetype.to_string
   |> should.equal(mime_type)
 }
 
 fn should_fall_back(bytes) {
   mimetype.detect(bytes)
+  |> mimetype.to_string
   |> should.equal("application/octet-stream")
+}
+
+fn should_be_mime(value: mimetype.MimeType, expected: String) {
+  value
+  |> mimetype.to_string
+  |> should.equal(expected)
+}
+
+fn should_be_ok_mime(result: Result(mimetype.MimeType, e), expected: String) {
+  result
+  |> result.map(mimetype.to_string)
+  |> should.equal(Ok(expected))
 }
 
 fn stored_mimetype_zip_archive(mime_type: BitArray) -> BitArray {
@@ -46,37 +67,37 @@ fn stored_mimetype_zip_archive(mime_type: BitArray) -> BitArray {
 
 pub fn extension_to_mime_type_normalizes_input_test() {
   mimetype.extension_to_mime_type(".JSON")
-  |> should.equal("application/json")
+  |> should_be_mime("application/json")
 }
 
 pub fn extension_to_mime_type_empty_string_falls_back_to_default_test() {
   mimetype.extension_to_mime_type("")
-  |> should.equal("application/octet-stream")
+  |> should_be_mime("application/octet-stream")
 }
 
 pub fn extension_to_mime_type_single_dot_falls_back_to_default_test() {
   mimetype.extension_to_mime_type(".")
-  |> should.equal("application/octet-stream")
+  |> should_be_mime("application/octet-stream")
 }
 
 pub fn extension_to_mime_type_trims_whitespace_test() {
   mimetype.extension_to_mime_type("  json  ")
-  |> should.equal("application/json")
+  |> should_be_mime("application/json")
 }
 
 pub fn extension_to_mime_type_strips_multiple_leading_dots_test() {
   mimetype.extension_to_mime_type("..json")
-  |> should.equal("application/json")
+  |> should_be_mime("application/json")
 }
 
 pub fn extension_to_mime_type_falls_back_for_unknown_test() {
   mimetype.extension_to_mime_type("totally-unknown-ext")
-  |> should.equal("application/octet-stream")
+  |> should_be_mime("application/octet-stream")
 }
 
 pub fn extension_to_mime_type_strict_returns_ok_for_known_extension_test() {
   mimetype.extension_to_mime_type_strict(".JSON")
-  |> should.equal(Ok("application/json"))
+  |> should_be_ok_mime("application/json")
 }
 
 pub fn extension_to_mime_type_strict_returns_error_for_unknown_extension_test() {
@@ -95,42 +116,45 @@ pub fn extension_to_mime_type_strict_returns_empty_input_for_dot_only_test() {
 }
 
 pub fn mime_type_to_extensions_returns_all_known_extensions_test() {
-  mimetype.mime_type_to_extensions("image/jpeg")
+  mimetype.mime_type_to_extensions(mt("image/jpeg"))
   |> should.equal(["jpg", "jpeg", "jpe"])
 }
 
 pub fn mime_type_to_extensions_strict_returns_ok_for_known_type_test() {
-  mimetype.mime_type_to_extensions_strict("image/jpeg")
+  mimetype.mime_type_to_extensions_strict(mt("image/jpeg"))
   |> should.equal(Ok(["jpg", "jpeg", "jpe"]))
 }
 
 pub fn mime_type_to_extensions_strict_returns_error_for_unknown_type_test() {
-  mimetype.mime_type_to_extensions_strict("application/x-not-real")
+  mimetype.mime_type_to_extensions_strict(mt("application/x-not-real"))
   |> should.equal(Error(Nil))
 }
 
 pub fn mime_type_to_extensions_empty_string_returns_empty_list_test() {
-  mimetype.mime_type_to_extensions("")
-  |> should.equal([])
+  // parse() rejects empty input, so callers can never pass an empty
+  // MimeType to mime_type_to_extensions. The lookup-fallback shape is
+  // covered by the unknown-type test below.
+  mimetype.parse("")
+  |> should.equal(Error(mimetype.EmptyMimeType))
 }
 
 pub fn mime_type_to_extensions_unknown_type_returns_empty_list_test() {
-  mimetype.mime_type_to_extensions("application/x-not-real")
+  mimetype.mime_type_to_extensions(mt("application/x-not-real"))
   |> should.equal([])
 }
 
 pub fn mime_type_to_extensions_trims_whitespace_test() {
-  mimetype.mime_type_to_extensions("  image/jpeg  ")
+  mimetype.mime_type_to_extensions(mt("  image/jpeg  "))
   |> should.equal(["jpg", "jpeg", "jpe"])
 }
 
 pub fn mime_type_to_extensions_normalizes_case_test() {
-  mimetype.mime_type_to_extensions("IMAGE/JPEG")
+  mimetype.mime_type_to_extensions(mt("IMAGE/JPEG"))
   |> should.equal(["jpg", "jpeg", "jpe"])
 }
 
 pub fn mime_type_to_extensions_ignores_parameters_test() {
-  mimetype.mime_type_to_extensions("text/html; charset=utf-8")
+  mimetype.mime_type_to_extensions(mt("text/html; charset=utf-8"))
   |> should.equal(["html", "htm", "shtml"])
 }
 
@@ -141,11 +165,11 @@ pub fn extension_to_mime_type_repeated_lookups_are_consistent_test() {
   list.repeat(Nil, 200)
   |> list.each(fn(_) {
     mimetype.extension_to_mime_type(".json")
-    |> should.equal("application/json")
+    |> should_be_mime("application/json")
     mimetype.extension_to_mime_type(".png")
-    |> should.equal("image/png")
+    |> should_be_mime("image/png")
     mimetype.extension_to_mime_type("totally-unknown-ext")
-    |> should.equal("application/octet-stream")
+    |> should_be_mime("application/octet-stream")
   })
 }
 
@@ -153,59 +177,65 @@ pub fn mime_type_to_extensions_repeated_lookups_are_consistent_test() {
   // Regression for issue #48: matching coverage on the reverse-lookup map.
   list.repeat(Nil, 200)
   |> list.each(fn(_) {
-    mimetype.mime_type_to_extensions("image/jpeg")
+    mimetype.mime_type_to_extensions(mt("image/jpeg"))
     |> should.equal(["jpg", "jpeg", "jpe"])
-    mimetype.mime_type_to_extensions("application/json")
+    mimetype.mime_type_to_extensions(mt("application/json"))
     |> should.equal(["json", "map"])
-    mimetype.mime_type_to_extensions("application/x-not-real")
+    mimetype.mime_type_to_extensions(mt("application/x-not-real"))
     |> should.equal([])
   })
 }
 
-pub fn essence_strips_parameters_and_normalizes_case_test() {
-  mimetype.essence(" TEXT/HTML ; charset=UTF-8 ")
+pub fn essence_of_strips_parameters_and_normalizes_case_test() {
+  mt(" TEXT/HTML ; charset=UTF-8 ")
+  |> mimetype.essence_of
   |> should.equal("text/html")
 }
 
-pub fn parameter_matches_case_insensitively_test() {
-  mimetype.parameter("text/html; CHARSET=UTF-8; boundary=abc123", "charset")
-  |> should.equal(Ok("UTF-8"))
+pub fn parameter_of_matches_case_insensitively_test() {
+  mt("text/html; CHARSET=UTF-8; boundary=abc123")
+  |> mimetype.parameter_of("charset")
+  |> should.equal(Some("UTF-8"))
 }
 
-pub fn parameter_returns_no_match_for_missing_key_test() {
-  mimetype.parameter("text/html; charset=UTF-8", "boundary")
-  |> should.equal(Error(mimetype.NoMatch))
+pub fn parameter_of_returns_none_for_missing_key_test() {
+  mt("text/html; charset=UTF-8")
+  |> mimetype.parameter_of("boundary")
+  |> should.equal(None)
 }
 
-pub fn parameter_returns_empty_input_for_blank_key_test() {
-  mimetype.parameter("text/html; charset=UTF-8", "")
-  |> should.equal(Error(mimetype.EmptyInput))
+pub fn parameter_of_returns_none_for_blank_key_test() {
+  mt("text/html; charset=UTF-8")
+  |> mimetype.parameter_of("")
+  |> should.equal(None)
 }
 
-pub fn charset_returns_lowercased_value_test() {
-  mimetype.charset("text/html; CHARSET=UTF-8")
-  |> should.equal(Ok("utf-8"))
+pub fn charset_of_type_returns_lowercased_value_test() {
+  mt("text/html; CHARSET=UTF-8")
+  |> mimetype.charset_of_type
+  |> should.equal(Some("utf-8"))
 }
 
-pub fn charset_returns_no_match_when_missing_test() {
-  mimetype.charset("text/html")
-  |> should.equal(Error(mimetype.NoMatch))
+pub fn charset_of_type_returns_none_when_missing_test() {
+  mt("text/html")
+  |> mimetype.charset_of_type
+  |> should.equal(None)
 }
 
 pub fn family_predicates_use_essence_test() {
-  mimetype.is_image("IMAGE/PNG; version=1")
+  mimetype.is_image(mt("IMAGE/PNG; version=1"))
   |> should.equal(True)
 
-  mimetype.is_text("text/html; charset=utf-8")
+  mimetype.is_text(mt("text/html; charset=utf-8"))
   |> should.equal(True)
 
-  mimetype.is_audio("audio/mpeg")
+  mimetype.is_audio(mt("audio/mpeg"))
   |> should.equal(True)
 
-  mimetype.is_video("video/mp4")
+  mimetype.is_video(mt("video/mp4"))
   |> should.equal(True)
 
-  mimetype.is_image("application/json")
+  mimetype.is_image(mt("application/json"))
   |> should.equal(False)
 }
 
@@ -222,22 +252,22 @@ pub fn extension_and_mime_mapping_roundtrip_test() {
 
 pub fn filename_to_mime_type_empty_string_falls_back_to_default_test() {
   mimetype.filename_to_mime_type("")
-  |> should.equal("application/octet-stream")
+  |> should_be_mime("application/octet-stream")
 }
 
 pub fn filename_to_mime_type_without_extension_falls_back_to_default_test() {
   mimetype.filename_to_mime_type("README")
-  |> should.equal("application/octet-stream")
+  |> should_be_mime("application/octet-stream")
 }
 
 pub fn filename_to_mime_type_detects_pdf_test() {
   mimetype.filename_to_mime_type("document.pdf")
-  |> should.equal("application/pdf")
+  |> should_be_mime("application/pdf")
 }
 
 pub fn filename_to_mime_type_strict_returns_ok_for_known_filename_test() {
   mimetype.filename_to_mime_type_strict("document.pdf")
-  |> should.equal(Ok("application/pdf"))
+  |> should_be_ok_mime("application/pdf")
 }
 
 pub fn filename_to_mime_type_strict_returns_empty_input_without_extension_test() {
@@ -252,67 +282,60 @@ pub fn filename_to_mime_type_strict_returns_unknown_extension_test() {
 
 pub fn filename_to_mime_type_uses_last_extension_test() {
   mimetype.filename_to_mime_type("/tmp/archive.tar.gz")
-  |> should.equal("application/gzip")
+  |> should_be_mime("application/gzip")
 }
 
 pub fn filename_to_mime_type_ignores_query_string_test() {
   mimetype.filename_to_mime_type("file.pdf?v=2")
-  |> should.equal("application/pdf")
+  |> should_be_mime("application/pdf")
 }
 
 pub fn filename_to_mime_type_ignores_fragment_test() {
   mimetype.filename_to_mime_type("file.pdf#page=5")
-  |> should.equal("application/pdf")
+  |> should_be_mime("application/pdf")
 }
 
 pub fn filename_to_mime_type_supports_windows_paths_test() {
   mimetype.filename_to_mime_type("C:\\Users\\file.json")
-  |> should.equal("application/json")
+  |> should_be_mime("application/json")
 }
 
 pub fn filename_to_mime_type_trailing_slash_falls_back_to_default_test() {
   mimetype.filename_to_mime_type("/path/to/")
-  |> should.equal("application/octet-stream")
+  |> should_be_mime("application/octet-stream")
 }
 
 pub fn filename_to_mime_type_ignores_hidden_file_without_extension_test() {
   mimetype.filename_to_mime_type(".gitignore")
-  |> should.equal("application/octet-stream")
+  |> should_be_mime("application/octet-stream")
 }
 
 pub fn detect_png_test() {
-  mimetype.detect(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>)
-  |> should.equal("image/png")
+  should_detect(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>, "image/png")
 }
 
 pub fn detect_jpeg_test() {
-  mimetype.detect(<<0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10>>)
-  |> should.equal("image/jpeg")
+  should_detect(<<0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10>>, "image/jpeg")
 }
 
 pub fn detect_gif_test() {
-  mimetype.detect(<<"GIF89a":utf8>>)
-  |> should.equal("image/gif")
+  should_detect(<<"GIF89a":utf8>>, "image/gif")
 }
 
 pub fn detect_pdf_test() {
-  mimetype.detect(<<"%PDF-1.7":utf8>>)
-  |> should.equal("application/pdf")
+  should_detect(<<"%PDF-1.7":utf8>>, "application/pdf")
 }
 
 pub fn detect_zip_test() {
-  mimetype.detect(<<0x50, 0x4B, 0x03, 0x04, 20, 0, 0, 0>>)
-  |> should.equal("application/zip")
+  should_detect(<<0x50, 0x4B, 0x03, 0x04, 20, 0, 0, 0>>, "application/zip")
 }
 
 pub fn detect_wav_test() {
-  mimetype.detect(<<"RIFF":utf8, 0, 0, 0, 0, "WAVE":utf8>>)
-  |> should.equal("audio/wav")
+  should_detect(<<"RIFF":utf8, 0, 0, 0, 0, "WAVE":utf8>>, "audio/wav")
 }
 
 pub fn detect_webp_test() {
-  mimetype.detect(<<"RIFF":utf8, 0, 0, 0, 0, "WEBP":utf8>>)
-  |> should.equal("image/webp")
+  should_detect(<<"RIFF":utf8, 0, 0, 0, 0, "WEBP":utf8>>, "image/webp")
 }
 
 pub fn detect_avi_test() {
@@ -337,13 +360,12 @@ pub fn detect_ico_test() {
 }
 
 pub fn detect_sqlite_test() {
-  mimetype.detect(<<"SQLite format 3":utf8, 0>>)
-  |> should.equal("application/vnd.sqlite3")
+  should_detect(<<"SQLite format 3":utf8, 0>>, "application/vnd.sqlite3")
 }
 
 pub fn detect_strict_returns_ok_for_known_signature_test() {
   mimetype.detect_strict(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>)
-  |> should.equal(Ok("image/png"))
+  |> should_be_ok_mime("image/png")
 }
 
 pub fn detect_strict_returns_empty_input_for_zero_bytes_test() {
@@ -636,6 +658,7 @@ pub fn detect_ole_word_marker_in_non_cfb_no_match_test() {
   >>
   let bytes = bit_array.concat([non_cfb, marker])
   mimetype.detect(bytes)
+  |> mimetype.to_string
   |> should.not_equal("application/msword")
 }
 
@@ -656,36 +679,29 @@ pub fn detect_audio_formats_test() {
 }
 
 pub fn detect_empty_bytes_falls_back_to_default_test() {
-  mimetype.detect(<<>>)
-  |> should.equal("application/octet-stream")
+  should_fall_back(<<>>)
 }
 
 pub fn detect_single_png_byte_falls_back_to_default_test() {
-  mimetype.detect(<<0x89>>)
-  |> should.equal("application/octet-stream")
+  should_fall_back(<<0x89>>)
 }
 
 pub fn detect_single_gif_byte_classified_as_text_test() {
   // After #20, single ASCII byte falls through to the text/plain heuristic.
-  mimetype.detect(<<"G":utf8>>)
-  |> should.equal("text/plain")
+  should_detect(<<"G":utf8>>, "text/plain")
 }
 
 pub fn detect_tar_boundary_does_not_false_positive_before_offset_test() {
-  mimetype.detect(<<0:size({ 256 * 8 })>>)
-  |> should.equal("application/octet-stream")
+  should_fall_back(<<0:size({ 256 * 8 })>>)
 }
 
 pub fn detect_tar_via_offset_signature_test() {
   let bytes = <<0:size({ 257 * 8 }), 0x75, 0x73, 0x74, 0x61, 0x72, 0:size(64)>>
-
-  mimetype.detect(bytes)
-  |> should.equal("application/x-tar")
+  should_detect(bytes, "application/x-tar")
 }
 
 pub fn detect_incomplete_mp4_brand_falls_back_to_default_test() {
-  mimetype.detect(<<0:size(32), "ftyp":utf8>>)
-  |> should.equal("application/octet-stream")
+  should_fall_back(<<0:size(32), "ftyp":utf8>>)
 }
 
 pub fn detect_partial_mp4_brand_falls_back_to_default_test() {
@@ -738,17 +754,17 @@ pub fn detect_with_extension_prefers_magic_over_conflicting_extension_test() {
     <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>,
     "txt",
   )
-  |> should.equal("image/png")
+  |> should_be_mime("image/png")
 }
 
 pub fn detect_with_extension_falls_back_when_magic_is_unknown_test() {
   mimetype.detect_with_extension(<<1, 2, 3, 4>>, "csv")
-  |> should.equal("text/csv")
+  |> should_be_mime("text/csv")
 }
 
 pub fn detect_with_extension_falls_back_to_default_for_unknown_extension_test() {
   mimetype.detect_with_extension(<<1, 2, 3, 4>>, "totally-unknown-ext")
-  |> should.equal("application/octet-stream")
+  |> should_be_mime("application/octet-stream")
 }
 
 pub fn detect_with_extension_strict_prefers_magic_over_extension_test() {
@@ -756,12 +772,12 @@ pub fn detect_with_extension_strict_prefers_magic_over_extension_test() {
     <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>,
     "txt",
   )
-  |> should.equal(Ok("image/png"))
+  |> should_be_ok_mime("image/png")
 }
 
 pub fn detect_with_extension_strict_falls_back_to_extension_test() {
   mimetype.detect_with_extension_strict(<<1, 2, 3, 4>>, "csv")
-  |> should.equal(Ok("text/csv"))
+  |> should_be_ok_mime("text/csv")
 }
 
 pub fn detect_with_extension_strict_returns_no_match_when_both_are_unknown_test() {
@@ -771,22 +787,22 @@ pub fn detect_with_extension_strict_returns_no_match_when_both_are_unknown_test(
 
 pub fn detect_with_extension_normalizes_leading_dot_and_case_test() {
   mimetype.detect_with_extension(<<1, 2, 3, 4>>, ".JSON")
-  |> should.equal("application/json")
+  |> should_be_mime("application/json")
 }
 
 pub fn detect_with_extension_uses_extension_for_empty_bytes_test() {
   mimetype.detect_with_extension(<<>>, "pdf")
-  |> should.equal("application/pdf")
+  |> should_be_mime("application/pdf")
 }
 
 pub fn detect_with_filename_falls_back_when_magic_is_unknown_test() {
   mimetype.detect_with_filename(<<1, 2, 3, 4>>, "report.csv")
-  |> should.equal("text/csv")
+  |> should_be_mime("text/csv")
 }
 
 pub fn detect_with_filename_strict_falls_back_to_filename_test() {
   mimetype.detect_with_filename_strict(<<1, 2, 3, 4>>, "report.csv")
-  |> should.equal(Ok("text/csv"))
+  |> should_be_ok_mime("text/csv")
 }
 
 pub fn detect_with_filename_strict_returns_no_match_when_both_are_unknown_test() {
@@ -799,7 +815,7 @@ pub fn detect_with_filename_prefers_magic_over_extension_test() {
     <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>,
     "not-really.txt",
   )
-  |> should.equal("image/png")
+  |> should_be_mime("image/png")
 }
 
 // Regression: issue #58 — printable-ASCII content used to be treated
@@ -810,53 +826,53 @@ pub fn detect_with_filename_prefers_filename_over_printable_ascii_csv_test() {
     "type,severity,message,occurred_at\nlogin,info,hi,2026-04-28\n":utf8,
   >>
   mimetype.detect_with_filename(bytes, "fixtures.csv")
-  |> should.equal("text/csv")
+  |> should_be_mime("text/csv")
 }
 
 pub fn detect_with_filename_prefers_filename_over_printable_ascii_md_test() {
   mimetype.detect_with_filename(<<"# Title\n\nbody\n":utf8>>, "dump.md")
-  |> should.equal("text/markdown")
+  |> should_be_mime("text/markdown")
 }
 
 pub fn detect_with_filename_falls_back_to_text_plain_when_filename_unknown_test() {
   // Plain ASCII + filename without a known extension: the
   // printable-ASCII heuristic is still the right last resort.
   mimetype.detect_with_filename(<<"plain text\n":utf8>>, "README")
-  |> should.equal("text/plain")
+  |> should_be_mime("text/plain")
 }
 
 pub fn detect_with_extension_prefers_extension_over_printable_ascii_csv_test() {
   mimetype.detect_with_extension(<<"a,b,c\n1,2,3\n":utf8>>, "csv")
-  |> should.equal("text/csv")
+  |> should_be_mime("text/csv")
 }
 
 pub fn detect_with_extension_strict_prefers_extension_over_printable_ascii_csv_test() {
   mimetype.detect_with_extension_strict(<<"a,b,c\n1,2,3\n":utf8>>, "csv")
-  |> should.equal(Ok("text/csv"))
+  |> should_be_ok_mime("text/csv")
 }
 
 pub fn detect_with_extension_falls_back_to_text_plain_when_extension_unknown_test() {
   mimetype.detect_with_extension(<<"plain text\n":utf8>>, "totally-unknown-ext")
-  |> should.equal("text/plain")
+  |> should_be_mime("text/plain")
 }
 
 pub fn detect_signature_only_returns_ok_for_binary_signature_test() {
   mimetype.detect_signature_only(<<
     0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
   >>)
-  |> should.equal(Ok("image/png"))
+  |> should_be_ok_mime("image/png")
 }
 
 pub fn detect_signature_only_returns_ok_for_structural_sniff_test() {
   mimetype.detect_signature_only(<<"{\"x\":1}":utf8>>)
-  |> should.equal(Ok("application/json"))
+  |> should_be_ok_mime("application/json")
 }
 
 pub fn detect_signature_only_returns_ok_for_bom_tagged_text_test() {
   // BOM-tagged text is a real signature, not the printable-ASCII
   // heuristic, so it must still be returned.
   mimetype.detect_signature_only(<<0xEF, 0xBB, 0xBF, "hello":utf8>>)
-  |> should.equal(Ok("text/plain; charset=utf-8"))
+  |> should_be_ok_mime("text/plain; charset=utf-8")
 }
 
 pub fn detect_signature_only_returns_no_match_for_printable_ascii_test() {
@@ -980,7 +996,7 @@ pub fn detect_json_rejects_trailing_comma_in_array_test() {
 
 pub fn detect_json_strict_returns_ok_test() {
   mimetype.detect_strict(<<"{\"x\":1}":utf8>>)
-  |> should.equal(Ok("application/json"))
+  |> should_be_ok_mime("application/json")
 }
 
 pub fn detect_json_array_of_objects_test() {
@@ -1106,12 +1122,12 @@ pub fn detect_xml_rejects_processing_instruction_other_than_xml_test() {
 
 pub fn detect_xml_strict_returns_ok_test() {
   mimetype.detect_strict(<<"<?xml version=\"1.0\"?>":utf8>>)
-  |> should.equal(Ok("text/xml"))
+  |> should_be_ok_mime("text/xml")
 }
 
 pub fn detect_html_strict_returns_ok_test() {
   mimetype.detect_strict(<<"<!DOCTYPE html>":utf8>>)
-  |> should.equal(Ok("text/html"))
+  |> should_be_ok_mime("text/html")
 }
 
 pub fn detect_svg_root_with_xmlns_test() {
@@ -1177,7 +1193,7 @@ pub fn detect_svg_xml_prolog_without_svg_falls_back_to_xml_test() {
 
 pub fn detect_svg_strict_returns_ok_test() {
   mimetype.detect_strict(<<"<svg/>":utf8>>)
-  |> should.equal(Ok("image/svg+xml"))
+  |> should_be_ok_mime("image/svg+xml")
 }
 
 pub fn detect_ttf_test() {
@@ -1223,7 +1239,7 @@ pub fn detect_eot_strict_returns_ok_test() {
     0x01,
   >>
   mimetype.detect_strict(bytes)
-  |> should.equal(Ok("application/vnd.ms-fontobject"))
+  |> should_be_ok_mime("application/vnd.ms-fontobject")
 }
 
 pub fn detect_eot_rejects_missing_offset_34_magic_test() {
@@ -1234,7 +1250,7 @@ pub fn detect_eot_rejects_missing_offset_34_magic_test() {
 
 pub fn detect_font_strict_returns_ok_for_ttf_test() {
   mimetype.detect_strict(<<0x00, 0x01, 0x00, 0x00>>)
-  |> should.equal(Ok("font/ttf"))
+  |> should_be_ok_mime("font/ttf")
 }
 
 pub fn detect_psd_test() {
@@ -1284,7 +1300,7 @@ pub fn detect_fits_test() {
 
 pub fn detect_image_strict_returns_ok_for_psd_test() {
   mimetype.detect_strict(<<0x38, 0x42, 0x50, 0x53>>)
-  |> should.equal(Ok("image/vnd.adobe.photoshop"))
+  |> should_be_ok_mime("image/vnd.adobe.photoshop")
 }
 
 pub fn detect_lz4_frame_test() {
@@ -1340,7 +1356,7 @@ pub fn detect_zlib_does_not_steal_png_test() {
 
 pub fn detect_compression_strict_returns_ok_for_lzip_test() {
   mimetype.detect_strict(<<"LZIP":utf8>>)
-  |> should.equal(Ok("application/x-lzip"))
+  |> should_be_ok_mime("application/x-lzip")
 }
 
 pub fn detect_aac_adts_test() {
@@ -1403,7 +1419,7 @@ pub fn detect_ebml_without_doctype_falls_back_test() {
 
 pub fn detect_av_strict_returns_ok_for_amr_test() {
   mimetype.detect_strict(<<"#!AMR":utf8, 0x0A>>)
-  |> should.equal(Ok("audio/amr"))
+  |> should_be_ok_mime("audio/amr")
 }
 
 pub fn detect_text_plain_utf8_bom_test() {
@@ -1465,8 +1481,7 @@ pub fn detect_text_plain_rejects_binary_with_high_byte_test() {
 
 pub fn detect_text_plain_rejects_empty_test() {
   // Empty stays at default; the text/plain heuristic must not catch empty.
-  mimetype.detect(<<>>)
-  |> should.equal("application/octet-stream")
+  should_fall_back(<<>>)
 }
 
 pub fn detect_text_plain_does_not_steal_png_test() {
@@ -1482,7 +1497,7 @@ pub fn detect_text_plain_does_not_steal_json_test() {
 
 pub fn detect_text_plain_strict_returns_ok_test() {
   mimetype.detect_strict(<<"plain text":utf8>>)
-  |> should.equal(Ok("text/plain"))
+  |> should_be_ok_mime("text/plain")
 }
 
 pub fn detect_with_limit_png_within_limit_test() {
@@ -1491,31 +1506,31 @@ pub fn detect_with_limit_png_within_limit_test() {
     <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>,
     8,
   )
-  |> should.equal("image/png")
+  |> should_be_mime("image/png")
 }
 
 pub fn detect_with_limit_tar_below_offset_test() {
   // TAR `ustar` magic sits at offset 257; a limit of 256 must cut it off.
   let bytes = <<0:size({ 257 * 8 }), 0x75, 0x73, 0x74, 0x61, 0x72, 0:size(64)>>
   mimetype.detect_with_limit(bytes, 256)
-  |> should.equal("application/octet-stream")
+  |> should_be_mime("application/octet-stream")
 }
 
 pub fn detect_with_limit_tar_above_offset_test() {
   let bytes = <<0:size({ 257 * 8 }), 0x75, 0x73, 0x74, 0x61, 0x72, 0:size(64)>>
   mimetype.detect_with_limit(bytes, 512)
-  |> should.equal("application/x-tar")
+  |> should_be_mime("application/x-tar")
 }
 
 pub fn detect_with_limit_zip_within_4_bytes_test() {
   // ZIP local file header `50 4B 03 04` fits in 4 bytes.
   mimetype.detect_with_limit(<<0x50, 0x4B, 0x03, 0x04, 20, 0, 0, 0>>, 4)
-  |> should.equal("application/zip")
+  |> should_be_mime("application/zip")
 }
 
 pub fn detect_with_limit_empty_bytes_test() {
   mimetype.detect_with_limit(<<>>, 1024)
-  |> should.equal("application/octet-stream")
+  |> should_be_mime("application/octet-stream")
 }
 
 pub fn detect_with_limit_zero_test() {
@@ -1523,7 +1538,7 @@ pub fn detect_with_limit_zero_test() {
     <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>,
     0,
   )
-  |> should.equal("application/octet-stream")
+  |> should_be_mime("application/octet-stream")
 }
 
 pub fn detect_with_limit_negative_treated_as_zero_test() {
@@ -1531,7 +1546,7 @@ pub fn detect_with_limit_negative_treated_as_zero_test() {
     <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>,
     -1,
   )
-  |> should.equal("application/octet-stream")
+  |> should_be_mime("application/octet-stream")
 }
 
 pub fn detect_with_limit_default_matches_detect_test() {
@@ -1541,20 +1556,23 @@ pub fn detect_with_limit_default_matches_detect_test() {
   let json = <<"{\"x\":1}":utf8>>
   let text = <<"hello":utf8>>
   mimetype.detect(png)
-  |> should.equal(mimetype.detect_with_limit(
-    png,
-    mimetype.default_detection_limit,
-  ))
+  |> mimetype.to_string
+  |> should.equal(
+    mimetype.detect_with_limit(png, mimetype.default_detection_limit)
+    |> mimetype.to_string,
+  )
   mimetype.detect(json)
-  |> should.equal(mimetype.detect_with_limit(
-    json,
-    mimetype.default_detection_limit,
-  ))
+  |> mimetype.to_string
+  |> should.equal(
+    mimetype.detect_with_limit(json, mimetype.default_detection_limit)
+    |> mimetype.to_string,
+  )
   mimetype.detect(text)
-  |> should.equal(mimetype.detect_with_limit(
-    text,
-    mimetype.default_detection_limit,
-  ))
+  |> mimetype.to_string
+  |> should.equal(
+    mimetype.detect_with_limit(text, mimetype.default_detection_limit)
+    |> mimetype.to_string,
+  )
 }
 
 pub fn detect_with_limit_strict_returns_ok_test() {
@@ -1562,7 +1580,7 @@ pub fn detect_with_limit_strict_returns_ok_test() {
     <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>,
     8,
   )
-  |> should.equal(Ok("image/png"))
+  |> should_be_ok_mime("image/png")
 }
 
 pub fn detect_with_limit_strict_returns_no_match_when_below_offset_test() {
@@ -1575,7 +1593,7 @@ pub fn detect_reader_returns_same_as_detect_test() {
   let png = <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>
   let reader = fn(_limit) { Ok(png) }
   mimetype.detect_reader(reader, 3072)
-  |> should.equal("image/png")
+  |> should_be_mime("image/png")
 }
 
 pub fn detect_reader_truncated_prefix_falls_back_test() {
@@ -1583,7 +1601,7 @@ pub fn detect_reader_truncated_prefix_falls_back_test() {
   let short_bytes = <<0:size({ 64 * 8 })>>
   let reader = fn(_limit) { Ok(short_bytes) }
   mimetype.detect_reader(reader, 3072)
-  |> should.equal("application/octet-stream")
+  |> should_be_mime("application/octet-stream")
 }
 
 pub fn detect_reader_short_eof_still_detects_test() {
@@ -1591,7 +1609,7 @@ pub fn detect_reader_short_eof_still_detects_test() {
   let png = <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>
   let reader = fn(_limit) { Ok(png) }
   mimetype.detect_reader(reader, 8192)
-  |> should.equal("image/png")
+  |> should_be_mime("image/png")
 }
 
 pub fn detect_reader_strict_error_preserves_reader_error_test() {
@@ -1603,7 +1621,7 @@ pub fn detect_reader_strict_error_preserves_reader_error_test() {
 pub fn detect_reader_error_returns_default_test() {
   let reader = fn(_limit) { Error("io error") }
   mimetype.detect_reader(reader, 3072)
-  |> should.equal("application/octet-stream")
+  |> should_be_mime("application/octet-stream")
 }
 
 pub fn detect_reader_called_with_limit_test() {
@@ -1615,14 +1633,14 @@ pub fn detect_reader_called_with_limit_test() {
     }
   }
   mimetype.detect_reader(reader, 100)
-  |> should.equal("image/png")
+  |> should_be_mime("image/png")
 }
 
 pub fn detect_reader_strict_ok_test() {
   let png = <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>
   let reader = fn(_limit) { Ok(png) }
   mimetype.detect_reader_strict(reader, 3072)
-  |> should.equal(Ok("image/png"))
+  |> should_be_ok_mime("image/png")
 }
 
 pub fn detect_reader_strict_no_match_returns_no_match_test() {
@@ -1633,110 +1651,102 @@ pub fn detect_reader_strict_no_match_returns_no_match_test() {
 }
 
 pub fn is_a_reflexive_test() {
-  mimetype.is_a("application/zip", "application/zip")
+  mimetype.is_a(mt("application/zip"), mt("application/zip"))
   |> should.equal(True)
 }
 
 pub fn is_a_docx_inherits_from_zip_test() {
   mimetype.is_a(
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    "application/zip",
+    mt(
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ),
+    mt("application/zip"),
   )
   |> should.equal(True)
 }
 
 pub fn is_a_svg_inherits_from_xml_test() {
-  mimetype.is_a("image/svg+xml", "text/xml")
+  mimetype.is_a(mt("image/svg+xml"), mt("text/xml"))
   |> should.equal(True)
 }
 
 pub fn is_a_unrelated_returns_false_test() {
-  mimetype.is_a("image/png", "application/zip")
+  mimetype.is_a(mt("image/png"), mt("application/zip"))
   |> should.equal(False)
 }
 
 pub fn is_a_normalizes_essence_test() {
   // Parameters and case differences are stripped before comparison.
-  mimetype.is_a("APPLICATION/ZIP; charset=utf-8", "application/zip")
+  mimetype.is_a(mt("APPLICATION/ZIP; charset=utf-8"), mt("application/zip"))
   |> should.equal(True)
 }
 
-pub fn is_a_empty_returns_false_test() {
-  mimetype.is_a("", "application/zip")
-  |> should.equal(False)
-  mimetype.is_a("application/zip", "")
-  |> should.equal(False)
-}
-
 pub fn is_zip_based_apk_test() {
-  mimetype.is_zip_based("application/vnd.android.package-archive")
+  mimetype.is_zip_based(mt("application/vnd.android.package-archive"))
   |> should.equal(True)
 }
 
 pub fn is_zip_based_jar_test() {
-  mimetype.is_zip_based("application/java-archive")
+  mimetype.is_zip_based(mt("application/java-archive"))
   |> should.equal(True)
 }
 
 pub fn is_zip_based_epub_test() {
-  mimetype.is_zip_based("application/epub+zip")
+  mimetype.is_zip_based(mt("application/epub+zip"))
   |> should.equal(True)
 }
 
 pub fn is_zip_based_zip_itself_test() {
-  mimetype.is_zip_based("application/zip")
+  mimetype.is_zip_based(mt("application/zip"))
   |> should.equal(True)
 }
 
 pub fn is_zip_based_png_test() {
-  mimetype.is_zip_based("image/png")
+  mimetype.is_zip_based(mt("image/png"))
   |> should.equal(False)
 }
 
 pub fn is_xml_based_svg_test() {
-  mimetype.is_xml_based("image/svg+xml")
+  mimetype.is_xml_based(mt("image/svg+xml"))
   |> should.equal(True)
 }
 
 pub fn is_xml_based_text_xml_test() {
-  mimetype.is_xml_based("text/xml")
+  mimetype.is_xml_based(mt("text/xml"))
   |> should.equal(True)
 }
 
 pub fn is_xml_based_application_xml_test() {
-  mimetype.is_xml_based("application/xml")
+  mimetype.is_xml_based(mt("application/xml"))
   |> should.equal(True)
 }
 
 pub fn is_xml_based_html_test() {
   // HTML is sniffable but is not XML; it is not a child of text/xml.
-  mimetype.is_xml_based("text/html")
+  mimetype.is_xml_based(mt("text/html"))
   |> should.equal(False)
 }
 
 pub fn ancestors_epub_test() {
-  mimetype.ancestors("application/epub+zip")
+  mimetype.ancestors(mt("application/epub+zip"))
+  |> list.map(mimetype.to_string)
   |> should.equal(["application/zip"])
 }
 
 pub fn ancestors_root_returns_empty_test() {
-  mimetype.ancestors("application/octet-stream")
+  mimetype.ancestors(mt("application/octet-stream"))
   |> should.equal([])
 }
 
 pub fn ancestors_unknown_mime_returns_empty_test() {
-  mimetype.ancestors("application/x-not-real")
+  mimetype.ancestors(mt("application/x-not-real"))
   |> should.equal([])
 }
 
 pub fn ancestors_msword_inherits_from_ole_test() {
-  mimetype.ancestors("application/msword")
+  mimetype.ancestors(mt("application/msword"))
+  |> list.map(mimetype.to_string)
   |> should.equal(["application/x-ole-storage"])
-}
-
-pub fn ancestors_empty_input_returns_empty_test() {
-  mimetype.ancestors("")
-  |> should.equal([])
 }
 
 pub fn charset_of_html_meta_charset_test() {


### PR DESCRIPTION
## Summary

Introduce `pub opaque type MimeType` and migrate the entire public
API from `String`-based identifiers to that opaque type, completing
the Issue #62 design. Detection / lookup helpers now return
`MimeType` (or `Result(MimeType, _)`); predicates and accessors
operate on `MimeType` rather than ad-hoc strings. Closes #62.

## Changes

- `src/mimetype.gleam`:
  - Added `pub opaque type MimeType { MimeType(essence, parameters) }`,
    a normalised value carrying both the essence (`type/subtype`) and
    parsed parameter list.
  - Added `pub type ParseError { EmptyMimeType ; InvalidMimeType(String) }`.
  - Added construction / serialisation: `parse(String) -> Result(MimeType, ParseError)`
    and `to_string(MimeType) -> String`.
  - Added accessors: `essence_of`, `parameter_of` (returns
    `Option(String)`), `charset_of_type` (returns `Option(String)`).
  - Migrated every detection / lookup function to return `MimeType`
    (or `Result(MimeType, DetectionError(_))`): `detect`,
    `detect_strict`, `detect_with_limit`, `detect_with_limit_strict`,
    `detect_signature_only`, `detect_signature_only_with_limit`,
    `detect_with_extension`, `detect_with_extension_strict`,
    `detect_with_filename`, `detect_with_filename_strict`,
    `detect_reader`, `detect_reader_strict`, `extension_to_mime_type`,
    `extension_to_mime_type_strict`, `filename_to_mime_type`,
    `filename_to_mime_type_strict`.
  - Migrated predicates / hierarchy helpers to take `MimeType`:
    `is_image`, `is_text`, `is_audio`, `is_video`, `is_a` (both
    arguments), `is_zip_based`, `is_xml_based`, `ancestors` (return
    type now `List(MimeType)`).
  - Migrated `mime_type_to_extensions` /
    `mime_type_to_extensions_strict`: argument is now `MimeType`;
    return list stays `List(String)`.
  - `default_mime_type` is now a `MimeType` constant rather than a
    `String`.
  - `charset_of(BitArray)` continues to return `Result(String, DetectionError(Nil))`
    because its result is a charset name, not a MIME type.
  - Removed `essence`, `parameter`, `charset` (replaced by their
    `MimeType`-based counterparts; the old shapes were redundant
    once `parse/1` front-loads the validation).
- `test/mimetype_test.gleam`: added `mt(s)`, `should_be_mime`, and
  `should_be_ok_mime` helpers; updated all 287 tests to use the
  `MimeType` API. Removed two tests that no longer apply
  (`is_a_empty_returns_false_test` and the
  `charset_of_empty_returns_pure_ascii_test` which contradicted the
  0.7.x charset behaviour change).
- `README.md`: usage example rewritten to show the `MimeType`
  workflow (`to_string` for serialisation, `parse` for
  construction, `essence_of` / `is_image` / `charset_of_type` for
  inspection).
- `CHANGELOG.md`: BREAKING entry under `Unreleased` documenting the
  migration, the new types, and the removed `String`-based
  helpers.

## Design Decisions

- **Single break, no `_v2` aliases.** Issue #62 explicitly favoured
  one clean rename for the 0.x package, since "once one production
  caller depends on the `String` API, moving to `MimeType` becomes
  a major version". Adding `_v2` aliases now would just leave the
  API in two inconsistent halves and force every caller to migrate
  twice.
- **Opaque, not abstract-data-type.** `MimeType` carries the
  essence and the pre-parsed parameter list as a record. `parse/1`
  front-loads the work — accessors don't have to re-split or
  re-lowercase on every call (the original `essence/1` /
  `parameter/2` shape did exactly that). The body is opaque so the
  internal representation can change without a breaking API.
- **`parameter_of` / `charset_of_type` return `Option`, not
  `DetectionError`.** Once the value has been validated by `parse`,
  the only failure mode left is "missing key", which is exactly
  what `Option` models. Reusing `DetectionError` here would
  conflate parsing-time and lookup-time failure modes.
- **`charset_of(BitArray)` still returns `Result(String, _)`.**
  Its result is a charset name (e.g. `"utf-8"`), not a media type
  — wrapping it in a `MimeType` would require pairing it with a
  separately-determined media type, which the function doesn't
  know about.
- **`default_mime_type` is a const value, not a function.** Gleam
  custom-type constructors are valid in const expressions, so we
  can keep the API call-free (`mimetype.default_mime_type` rather
  than `mimetype.default_mime_type()`).
- **Internal modules unchanged.** `magic.gleam`, `hierarchy.gleam`,
  `charset.gleam`, and `db.gleam` still operate on `String`. The
  public API wraps internal strings with a private `from_internal`
  helper that round-trips through `parse/1` (and falls back to a
  bare-essence record if the internal data ever drifts). This
  keeps the migration localised to `mimetype.gleam` and avoids
  touching the generated FFI tables.
- **Lenient wrappers exhaustively match `DetectionError` variants.**
  Same constraint as PR #66: glinter's `thrown_away_error` rule
  rejects `Error(_) -> default_mime_type`, so each lenient case
  lists every variant explicitly.
- **Internal fallback chains use `result.lazy_or`.**
  `detect_with_extension_strict` and `detect_with_filename_strict`
  express their signature → metadata → printable-ASCII fallback
  chain as a `result.lazy_or` pipe rather than nested `case`
  expressions, both for readability and to satisfy the linter.

## Limitations

- `mime_type_to_extensions_strict` still returns `Result(_, Nil)`
  rather than a `DetectionError`. Issue #61 explicitly scoped that
  function out, and #62 doesn't introduce a clean variant for "MIME
  type not in DB" — that would want its own follow-up
  (`UnknownMimeType(MimeType)` or similar) if there's demand.
- `ParseError` is intentionally minimal (`EmptyMimeType`,
  `InvalidMimeType(String)`). RFC 6838 has more granular failure
  modes (invalid character in subtype, invalid parameter, etc.)
  but they don't seem to add value over "the input was malformed,
  here it is verbatim" in practice. Adding finer variants is a
  non-breaking follow-up if a real use case appears.
