### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.8.0] - 2026-04-29
+
 ### Added
 
 - Detect OpenDocument ZIP containers via their required leading

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "mimetype"
-version = "0.7.0"
+version = "0.8.0"
 description = "MIME type lookup and magic-number detection for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "mimetype" }


### PR DESCRIPTION
### Added

- Detect OpenDocument ZIP containers via their required leading
  `mimetype` entry: `application/vnd.oasis.opendocument.text`
  (`.odt`), `application/vnd.oasis.opendocument.spreadsheet`
  (`.ods`), and `application/vnd.oasis.opendocument.presentation`
  (`.odp`). This brings content-based detection into line with the
  existing extension database and ZIP subtype hierarchy.
- **`pub opaque type MimeType`**: a normalised, validated MIME type
  value carrying both the essence (`type/subtype`) and the parsed
  parameter list. All detection / lookup helpers now return
  `MimeType` (or `Result(MimeType, _)`); predicates and accessors
  operate on `MimeType` rather than ad-hoc strings. Construction:
    - `parse(String) -> Result(MimeType, ParseError)` — wire-format
      parser. Returns `Error(EmptyMimeType)` for empty input and
      `Error(InvalidMimeType(original))` for malformed essences.
    - `to_string(MimeType) -> String` — serialise back to the
      wire format (round-trippable through `parse`).
  Accessors:
    - `essence_of(MimeType) -> String`
    - `parameter_of(MimeType, String) -> Option(String)`
    - `charset_of_type(MimeType) -> Option(String)`
- **`ParseError`** type, with `EmptyMimeType` and
  `InvalidMimeType(String)` variants, returned by `parse/1`.

### Changed

- **API-wide `String` → `MimeType` (BREAKING)**: every detection
  and lookup function now returns `MimeType` (or
  `Result(MimeType, DetectionError(_))`) instead of a bare
  `String`. Predicates and ancestor helpers take `MimeType`.
  `default_mime_type` is now a `MimeType` constant. Migration:
  pipe results through `to_string` for serialisation or
  `essence_of` for `type/subtype`; replace bare-string arguments
  with `parse(s)`. `charset_of(BitArray)` continues to return a
  charset name, not a `MimeType`. Closes #62. (#62)
- **Strict family (BREAKING)**: the ten strict-family functions
  (`detect_strict`, `detect_with_limit_strict`,
  `detect_signature_only`, `detect_signature_only_with_limit`,
  `detect_with_extension_strict`, `detect_with_filename_strict`,
  `extension_to_mime_type_strict`, `filename_to_mime_type_strict`,
  `charset_of`) now return `Result(_, DetectionError(Nil))` with
  two new variants alongside `NoMatch` and `ReaderError(_)`:
  `EmptyInput` (zero-byte / empty input) and
  `UnknownExtension(String)` (the lookup key was not in the
  database). Closes the rest of #61. (#61)
- **`charset_of` (BREAKING, behaviour change)**: now returns
  `Error(EmptyInput)` for the zero-byte `BitArray` rather than
  `Ok("us-ascii")`. Non-empty inputs whose encoding cannot be
  determined now return `Error(NoMatch)`.

### Removed

- **`essence(String) -> String` (BREAKING)** — replaced by
  `essence_of(MimeType) -> String`.
- **`parameter(String, String) -> Result(String, _)` (BREAKING)** —
  replaced by `parameter_of(MimeType, String) -> Option(String)`.
- **`charset(String) -> Result(String, _)` (BREAKING)** — replaced
  by `charset_of_type(MimeType) -> Option(String)`.

### Documentation

- README now describes the actual shallow ZIP-container inspection
  behavior. The previous wording incorrectly implied that ZIP-based
  Office-family formats were not distinguished at all.
- README's `detect_strict(<<>>)` example shows the new
  `Error(EmptyInput)` shape.
- README usage block rewritten to show the `MimeType` workflow:
  `to_string` for serialisation, `parse` for construction,
  `essence_of` / `is_image` / `charset_of_type` for inspection.
