### PR TITLE
fix(parse): strip surrounding quotes and decode escapes in quoted-string parameter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`parse`** now strips the surrounding `"` delimiters from quoted-string
+  parameter values per RFC 7230 §3.2.6, and decodes backslash escapes
+  inside (`\X` → `X`). `parameter_of(parse("text/html; charset=\"utf-8\""), "charset")`
+  now returns `Some("utf-8")` instead of `Some("\"utf-8\"")`. The same
+  fix unwraps quoted boundaries (`boundary="foo\"bar"` decodes to `foo"bar`)
+  and stabilises round-tripping through `to_string` + `parse`. Token-form
+  values pass through unchanged. Malformed inputs (lone `"`, unmatched
+  leading `"`, trailing lone `\`) are passed through unchanged so the
+  parser stays tolerant of off-spec wire input. (#69)
+
 ## [0.8.0] - 2026-04-29
 
 ### Added

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -631,15 +631,49 @@ fn parse_parameters(segments: List(String)) -> List(#(String, String)) {
     case string.split_once(seg, on: "=") {
       Ok(#(name, value)) -> {
         let normalized_name = name |> string.trim |> string.lowercase
-        let trimmed_value = string.trim(value)
+        let normalized_value = value |> string.trim |> unquote_value
         case normalized_name {
           "" -> Error(Nil)
-          _ -> Ok(#(normalized_name, trimmed_value))
+          _ -> Ok(#(normalized_name, normalized_value))
         }
       }
       Error(Nil) -> Error(Nil)
     }
   })
+}
+
+/// Unwrap a parameter value from RFC 7230 §3.2.6 quoted-string form.
+///
+/// If `value` is delimited by surrounding `"`, strip them and decode any
+/// backslash escapes inside (`\X` → `X`). Values that are not delimited
+/// (token form per RFC 7230 §3.2.6) pass through unchanged. Malformed
+/// inputs — a leading `"` without a matching trailing `"`, or a trailing
+/// `\` with nothing after it — also pass through unchanged so the parser
+/// remains tolerant of off-spec wire input.
+fn unquote_value(value: String) -> String {
+  use <- bool.guard(
+    when: !{ string.starts_with(value, "\"") && string.ends_with(value, "\"") },
+    return: value,
+  )
+  // Reject the lone `"` case (length 1: starts AND ends match the
+  // same character, so the slice is empty but we'd otherwise
+  // discard the original character).
+  use <- bool.guard(when: string.length(value) < 2, return: value)
+  let inner = value |> string.drop_start(1) |> string.drop_end(1)
+  unescape_quoted(inner, "")
+}
+
+fn unescape_quoted(remaining: String, acc: String) -> String {
+  case string.pop_grapheme(remaining) {
+    Error(Nil) -> acc
+    Ok(#("\\", rest)) ->
+      case string.pop_grapheme(rest) {
+        Ok(#(escaped, after)) -> unescape_quoted(after, acc <> escaped)
+        // Trailing lone backslash: keep it as-is.
+        Error(Nil) -> acc <> "\\"
+      }
+    Ok(#(other, rest)) -> unescape_quoted(rest, acc <> other)
+  }
 }
 
 /// Build a `MimeType` from a string produced by an internal source

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -222,6 +222,71 @@ pub fn charset_of_type_returns_none_when_missing_test() {
   |> should.equal(None)
 }
 
+// RFC 7230 §3.2.6: parameter values may be expressed as quoted-string
+// (DQUOTE qdtext DQUOTE). The surrounding `"` are syntax, not part of
+// the value, so the parser must strip them.
+
+pub fn parameter_of_strips_surrounding_quotes_test() {
+  mt("text/html; charset=\"utf-8\"")
+  |> mimetype.parameter_of("charset")
+  |> should.equal(Some("utf-8"))
+}
+
+pub fn charset_of_type_strips_surrounding_quotes_test() {
+  mt("text/html; charset=\"UTF-8\"")
+  |> mimetype.charset_of_type
+  |> should.equal(Some("utf-8"))
+}
+
+pub fn parameter_of_unescapes_backslash_escapes_in_quoted_value_test() {
+  // RFC 7230 §3.2.6 quoted-pair: `\X` decodes to `X`. So
+  // `name="foo\"bar"` decodes to `foo"bar`.
+  mt("multipart/form-data; boundary=\"foo\\\"bar\"")
+  |> mimetype.parameter_of("boundary")
+  |> should.equal(Some("foo\"bar"))
+}
+
+pub fn parameter_of_unescapes_double_backslash_test() {
+  // `\\` decodes to a single `\`.
+  mt("text/plain; charset=\"a\\\\b\"")
+  |> mimetype.parameter_of("charset")
+  |> should.equal(Some("a\\b"))
+}
+
+pub fn parameter_of_token_value_unchanged_test() {
+  // Token-form (no surrounding quotes) values pass through unchanged.
+  mt("text/html; charset=utf-8")
+  |> mimetype.parameter_of("charset")
+  |> should.equal(Some("utf-8"))
+}
+
+pub fn parse_then_to_string_then_parse_quoted_value_round_trips_test() {
+  // After this fix, the round-trip parameter value is stable —
+  // previously the value would gain literal `"` quotes on each round
+  // and `to_string` would re-emit them, so the second parse would
+  // see `"\"utf-8\""` and so on.
+  let assert Ok(mt1) = mimetype.parse("text/html; charset=\"utf-8\"")
+  let serialised = mimetype.to_string(mt1)
+  let assert Ok(mt2) = mimetype.parse(serialised)
+  mimetype.parameter_of(mt2, "charset")
+  |> should.equal(Some("utf-8"))
+}
+
+pub fn parameter_of_lone_quote_passes_through_test() {
+  // A bare `"` (length 1) is malformed per RFC 7230 — pass through
+  // unchanged so the parser stays tolerant.
+  mt("text/html; charset=\"")
+  |> mimetype.parameter_of("charset")
+  |> should.equal(Some("\""))
+}
+
+pub fn parameter_of_unmatched_leading_quote_passes_through_test() {
+  // `"utf-8` (no trailing `"`) — pass through unchanged.
+  mt("text/html; charset=\"utf-8")
+  |> mimetype.parameter_of("charset")
+  |> should.equal(Some("\"utf-8"))
+}
+
 pub fn family_predicates_use_essence_test() {
   mimetype.is_image(mt("IMAGE/PNG; version=1"))
   |> should.equal(True)


### PR DESCRIPTION
## Summary

Fix `parse` so it correctly strips the surrounding `"` delimiters from quoted-string parameter values per RFC 7231 §3.1.1.2 and RFC 7230 §3.2.6, and decodes backslash escapes (`\X` → `X`) inside the quoted form. Without this fix, `parameter_of(parse("text/html; charset=\"utf-8\""), "charset")` returned `Some("\"utf-8\"")` (with literal quotes inside the value), and `parse |> to_string |> parse` was not value-stable for any quoted parameter.

## Changes

- `src/mimetype.gleam`: introduce `unquote_value` and `unescape_quoted` private helpers; route every parameter value in `parse_parameters` through `unquote_value` after trimming
- `test/mimetype_test.gleam`: add seven new tests covering the happy path (surrounding quotes stripped), backslash-escape decoding, double-backslash decoding, token-form values passing through unchanged, the round-trip stability gain, and the malformed-input tolerance cases (lone `"`, unmatched leading `"`)
- `CHANGELOG.md`: add `Fixed` entry under `Unreleased`

## Design Decisions

1. **Strip-and-unescape only when both delimiters are present.** A bare `"` (length 1) or an unmatched leading `"` is passed through unchanged. This keeps the parser tolerant of off-spec wire input — the same posture the rest of the file takes for malformed essences via `from_internal`.
2. **Backslash-escape decoding is grapheme-by-grapheme.** Per RFC 7230 §3.2.6, `\X` decodes to `X` for any single character `X`. A trailing lone `\` is kept as-is (rather than dropped) so the value's last character is never silently lost.
3. **Out of scope for this PR.** The higher-level splitter still uses `string.split(input, on: ";")` on the whole essence+parameters string, which would mis-split inputs like `text/html; param="a;b"`. That's a separate (and broader) follow-up; this PR fixes the issue exactly as filed and the new tests do not require the splitter change to pass.

Closes #69
