### PR TITLE
chore(release): prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.9.0] - 2026-04-29
+
 ### Fixed
 
 - **`parse`** now strips the surrounding `"` delimiters from quoted-string

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "mimetype"
-version = "0.8.0"
+version = "0.9.0"
 description = "MIME type lookup and magic-number detection for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "mimetype" }


### PR DESCRIPTION
### Fixed

- **`parse`** now strips the surrounding `"` delimiters from quoted-string
  parameter values per RFC 7230 §3.2.6, and decodes backslash escapes
  inside (`\X` → `X`). `parameter_of(parse("text/html; charset=\"utf-8\""), "charset")`
  now returns `Some("utf-8")` instead of `Some("\"utf-8\"")`. The same
  fix unwraps quoted boundaries (`boundary="foo\"bar"` decodes to `foo"bar`)
  and stabilises round-tripping through `to_string` + `parse`. Token-form
  values pass through unchanged. Malformed inputs (lone `"`, unmatched
  leading `"`, trailing lone `\`) are passed through unchanged so the
  parser stays tolerant of off-spec wire input. (#69)
