### PR TITLE
ci: add scheduled mime-db drift detection workflow (#72)

### DIFF
--- a/.github/workflows/refresh-mime-db.yml
+++ b/.github/workflows/refresh-mime-db.yml
@@ -1,0 +1,167 @@
+name: Refresh mime-db
+
+# Surface upstream jshttp/mime-db drift automatically. The job runs
+# generate_mime_db.sh against the current upstream main, regenerates
+# the embedded data tables, and — if the result differs from main — files
+# an issue summarising the upstream commit bump and the local diff so a
+# maintainer can review and merge a refresh PR by hand. The manual path
+# (just running scripts/generate_mime_db.sh locally) is unchanged; this
+# workflow is only the "did upstream move?" notifier.
+
+on:
+  schedule:
+    # Weekly, Monday 03:30 UTC. Off-peak for GitHub Actions and clearly
+    # outside of any release-cut window.
+    - cron: "30 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: refresh-mime-db
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Detect mime-db drift and file an issue
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: extractions/setup-just@v3
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "28"
+          gleam-version: "1.15.2"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Verify jq is available
+        run: jq --version
+
+      - name: Clone upstream mime-db
+        run: |
+          mkdir -p doc/reference/upstream
+          git clone --depth=1 https://github.com/jshttp/mime-db.git doc/reference/upstream/mime-db
+
+      - name: Capture upstream version and commit
+        id: upstream
+        run: |
+          set -eu
+          cd doc/reference/upstream/mime-db
+          version="$(jq -er '.version' package.json)"
+          commit="$(git rev-parse --short HEAD)"
+          long_commit="$(git rev-parse HEAD)"
+          {
+            echo "version=$version"
+            echo "commit=$commit"
+            echo "long_commit=$long_commit"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download dependencies
+        run: just deps
+
+      - name: Regenerate embedded mime-db tables
+        run: bash scripts/generate_mime_db.sh
+
+      - name: Diff against committed sources
+        id: diff
+        run: |
+          set -eu
+          if git diff --quiet -- src/mimetype/internal/db.gleam src/mimetype/internal/mimetype_db_ffi.erl src/mimetype/internal/db_ffi.mjs; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "drift=true" >> "$GITHUB_OUTPUT"
+          git diff --stat -- src/mimetype/internal/db.gleam src/mimetype/internal/mimetype_db_ffi.erl src/mimetype/internal/db_ffi.mjs > /tmp/diffstat.txt
+
+      - name: Look for an existing open drift issue
+        if: steps.diff.outputs.drift == 'true'
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          number="$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --label automation:mime-db-refresh \
+            --limit 1 \
+            --json number --jq '.[0].number // empty')"
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure label exists
+        if: steps.diff.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create automation:mime-db-refresh \
+            --repo "${{ github.repository }}" \
+            --description "Automated mime-db drift notification" \
+            --color BFD4F2 \
+            --force
+
+      - name: Build issue body
+        if: steps.diff.outputs.drift == 'true'
+        env:
+          UPSTREAM_VERSION: ${{ steps.upstream.outputs.version }}
+          UPSTREAM_COMMIT: ${{ steps.upstream.outputs.commit }}
+          UPSTREAM_LONG_COMMIT: ${{ steps.upstream.outputs.long_commit }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -eu
+          {
+            echo "Upstream [jshttp/mime-db](https://github.com/jshttp/mime-db) has moved past the version pinned in this repository."
+            echo ""
+            echo "- upstream version: \`${UPSTREAM_VERSION}\`"
+            echo "- upstream commit: [\`${UPSTREAM_COMMIT}\`](https://github.com/jshttp/mime-db/commit/${UPSTREAM_LONG_COMMIT})"
+            echo "- workflow: ${WORKFLOW_URL}"
+            echo ""
+            echo "### Local diff after regeneration"
+            echo ""
+            echo '```'
+            cat /tmp/diffstat.txt
+            echo '```'
+            echo ""
+            echo "### How to refresh manually"
+            echo ""
+            echo '```sh'
+            echo 'git clone https://github.com/jshttp/mime-db.git doc/reference/upstream/mime-db'
+            echo 'bash scripts/generate_mime_db.sh'
+            echo '```'
+            echo ""
+            echo "See [CONTRIBUTING.md \"Regenerating the extension database\"](../blob/main/CONTRIBUTING.md#regenerating-the-extension-database) and \"Automated upstream drift detection\" for the manual override path and the licence-notice rules that apply to regenerated FFI files."
+            echo ""
+            echo "---"
+            echo "*This issue was filed automatically by the \`refresh-mime-db\` workflow.*"
+          } > /tmp/issue-body.md
+
+      - name: File or update drift issue
+        if: steps.diff.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPSTREAM_VERSION: ${{ steps.upstream.outputs.version }}
+          UPSTREAM_COMMIT: ${{ steps.upstream.outputs.commit }}
+          EXISTING_NUMBER: ${{ steps.existing.outputs.number }}
+        run: |
+          set -eu
+          title="chore(mime-db): refresh to v${UPSTREAM_VERSION} (${UPSTREAM_COMMIT})"
+          if [ -n "$EXISTING_NUMBER" ]; then
+            gh issue comment "$EXISTING_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --body-file /tmp/issue-body.md
+            gh issue edit "$EXISTING_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --title "$title"
+          else
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "$title" \
+              --body-file /tmp/issue-body.md \
+              --label automation:mime-db-refresh
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Added
+
+- **automation**: scheduled `Refresh mime-db` workflow
+  (`.github/workflows/refresh-mime-db.yml`) runs weekly and on
+  `workflow_dispatch`. When upstream `jshttp/mime-db` has moved past
+  the pinned commit, the workflow regenerates the embedded data
+  tables in a fresh checkout, detects whether the output differs
+  from `main`, and files (or updates) an
+  `automation:mime-db-refresh`-labelled issue summarising the
+  upstream version, commit, and `git diff --stat` of the regenerated
+  files. The workflow does not push or open a PR — a maintainer
+  consumes the issue, runs the documented regeneration steps
+  locally, and opens a normal review PR. CONTRIBUTING.md is
+  extended with an "Automated upstream drift detection" section
+  documenting the workflow and the manual override path. (#72)
+
 ## [0.9.0] - 2026-04-29
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,29 @@ When changing the generation logic or updating the upstream data:
 3. Keep `THIRD_PARTY_NOTICES.md` aligned with the packaged third-party data
 4. Run `just ci`
 
+### Automated upstream drift detection
+
+The `Refresh mime-db` workflow (`.github/workflows/refresh-mime-db.yml`)
+runs every Monday at 03:30 UTC and on demand via *Actions → Refresh mime-db
+→ Run workflow*. It clones the latest `jshttp/mime-db`, regenerates the
+embedded data tables in a fresh checkout, and — only when the regenerated
+output differs from `main` — files (or updates) an issue tagged
+`automation:mime-db-refresh` summarising:
+
+- the upstream `package.json` version,
+- the upstream commit SHA, and
+- a `git diff --stat` of the regenerated files.
+
+The workflow does not push or open a PR. To consume a drift notification:
+
+1. Pick up the open `automation:mime-db-refresh` issue.
+2. Locally run the regeneration steps documented above.
+3. Open a normal PR with the regenerated files and link the issue.
+4. Close the issue when the PR merges.
+
+If you want to trigger a check off-cycle (e.g., to confirm the package
+is at parity right after release), use the `workflow_dispatch` button.
+
 ## Project structure
 
 `mimetype` intentionally splits the problem into two layers:


### PR DESCRIPTION
## Summary

Detect upstream `jshttp/mime-db` drift automatically instead of relying on ad hoc user reports. Closes #72.

## Changes

- `.github/workflows/refresh-mime-db.yml` — new scheduled workflow
  - cron: weekly Monday 03:30 UTC, plus `workflow_dispatch`
  - clones latest mime-db at depth 1
  - runs `scripts/generate_mime_db.sh` against the fresh checkout
  - on drift, files (or updates) an issue labelled `automation:mime-db-refresh` with the upstream version, commit (linked), and a `git diff --stat` of the regenerated files
  - permissions limited to `contents: read` + `issues: write`; uses the default `GITHUB_TOKEN`
- `CONTRIBUTING.md` — new "Automated upstream drift detection" subsection documenting how to consume a drift notification and the manual override path.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Design Decisions

- **Issue, not PR.** The issue says "open a PR or at least file an issue with the diff summary". Filing an issue keeps this workflow purely on `GITHUB_TOKEN` permissions (`issues: write`) and avoids the bot-PR / merge-conflict cleanup churn that comes with `peter-evans/create-pull-request@v6`. A maintainer reviews the diff in the issue, runs `bash scripts/generate_mime_db.sh` locally, and opens a normal review PR.
- **Upsert rather than spam.** The workflow looks up an open `automation:mime-db-refresh` issue first; if one exists it appends a comment and updates the title with the new version/commit instead of opening a duplicate. Maintainers see one issue per drift cycle.
- **No auto-push.** The job runs in a stock checkout, regenerates files into the working tree, and only inspects the diff. Nothing is pushed. The existing `mime-db-sync` CI job already enforces that committed sources match the pinned upstream commit on every PR, so the existing drift-on-merge check stays the source of truth for "the repo is consistent" — this workflow is only the upstream-moved notifier.
- **Off-peak schedule.** Monday 03:30 UTC avoids release-cut windows and weekday CI load.
- **`workflow_dispatch`** included so a maintainer can trigger a refresh check immediately after a release without waiting for the next Monday.
- **Body via file, not heredoc.** The issue body is built with a sequence of `echo` lines into a file and passed via `--body-file`. Avoids fragile heredoc indentation interactions with YAML block scalars and keeps escaping straightforward (literal backticks for code fences without `\`` gymnastics).

Closes #72
