### PR TITLE
chore(release): prepare v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.10.0] - 2026-04-30
+
 ### Added
 
 - **automation**: scheduled `Refresh mime-db` workflow

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "mimetype"
-version = "0.9.0"
+version = "0.10.0"
 description = "MIME type lookup and magic-number detection for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "mimetype" }


### PR DESCRIPTION
### Added

- **automation**: scheduled `Refresh mime-db` workflow
  (`.github/workflows/refresh-mime-db.yml`) runs weekly and on
  `workflow_dispatch`. When upstream `jshttp/mime-db` has moved past
  the pinned commit, the workflow regenerates the embedded data
  tables in a fresh checkout, detects whether the output differs
  from `main`, and files (or updates) an
  `automation:mime-db-refresh`-labelled issue summarising the
  upstream version, commit, and `git diff --stat` of the regenerated
  files. The workflow does not push or open a PR — a maintainer
  consumes the issue, runs the documented regeneration steps
  locally, and opens a normal review PR. CONTRIBUTING.md is
  extended with an "Automated upstream drift detection" section
  documenting the workflow and the manual override path. (#72)
