### PR TITLE
docs(readme): add reader-based detection guide with adapter patterns (#75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,133 @@ pub fn main() {
 }
 ```
 
+## Reader-based detection
+
+`detect_reader` and `detect_reader_strict` let callers detect a MIME
+type **without buffering the whole input**. They take a synchronous
+reader plus a byte budget, and the reader is invoked **at most once**
+to fetch up to that many bytes from the start of the source.
+
+### Reader contract
+
+```gleam
+pub type Reader(read_error) = fn(Int) -> Result(BitArray, read_error)
+```
+
+- The `Int` argument is the maximum number of bytes the detector wants.
+- Returning fewer bytes than requested is fine — it is interpreted as
+  "the source ended early". Detection runs against whatever was
+  returned.
+- The returned `BitArray` should always be the prefix starting at
+  offset 0 of the source. The detector inspects it from byte 0.
+- The error parameter `read_error` is opaque to the library; in the
+  strict variant it is preserved as `ReaderError(read_error)` so
+  callers can distinguish IO failures from "no signature matched".
+
+The reader is called **once per detection call**. There is no
+streaming or back-and-forth — return enough bytes for the largest
+signature you care about (the detector inspects up to a few KB by
+default), or pass a custom `limit` argument tuned for your workload.
+
+### In-memory adapter
+
+The simplest case: when the bytes are already in hand, wrap them in a
+function that ignores its argument.
+
+```gleam
+import mimetype
+
+pub fn main() {
+  let png = <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>
+  let reader = fn(_limit) { Ok(png) }
+
+  mimetype.detect_reader(reader, 3072)
+  |> mimetype.to_string
+  // -> "image/png"
+}
+```
+
+### BEAM file prefix reader
+
+On the Erlang target, wrap a file-IO library so that one call returns
+up to `limit` bytes from the start of the file. Any IO library that
+can open a file and read a fixed-size prefix works — the snippet below
+sketches the shape using a `read_prefix(path, limit)` helper that
+returns `Result(BitArray, your_error)`:
+
+```gleam
+import mimetype
+
+pub fn detect_file(path: String) -> Result(mimetype.MimeType, mimetype.DetectionError(your_error)) {
+  let reader = fn(limit) { read_prefix(path, limit) }
+  mimetype.detect_reader_strict(reader, 3072)
+}
+```
+
+If `read_prefix` returns `Ok(<<>>)` for an empty file, the strict
+variant surfaces `Error(EmptyInput)`. If `read_prefix` itself returns
+`Error(some_io_error)`, the strict variant surfaces
+`Error(ReaderError(some_io_error))` so the caller can distinguish IO
+failure from a genuine no-match.
+
+### JavaScript browser adapter
+
+In the browser, `File` / `Blob` / `ReadableStream` reads are
+asynchronous, so they cannot satisfy the synchronous `Reader`
+contract directly. The intended pattern is:
+
+1. Read the prefix asynchronously (`await blob.slice(0, limit).arrayBuffer()`
+   or the equivalent on a `ReadableStream`).
+2. Pass the resulting bytes to `detect` / `detect_strict`, **not** to
+   `detect_reader`.
+
+In Gleam pseudo-code, with an FFI helper `read_blob_prefix` that
+awaits the slice and returns a `BitArray`:
+
+```gleam
+import mimetype
+
+pub fn detect_blob(blob: Blob) -> mimetype.MimeType {
+  // `read_blob_prefix` is your FFI: await blob.slice(0, 3072).arrayBuffer()
+  let bytes = read_blob_prefix(blob, 3072)
+  mimetype.detect(bytes)
+}
+```
+
+The reader-based API is most useful when the source is itself
+synchronous (BEAM file IO, in-memory buffers, deterministic stream
+adapters). For Promise-based sources, awaiting the prefix once and
+calling `detect` is the recommended shape.
+
+### Strict variants and error handling
+
+The strict variants return `Result(MimeType, DetectionError(read_error))`,
+where `DetectionError` distinguishes:
+
+- `EmptyInput` — the reader returned a zero-byte payload, so no
+  detection was possible.
+- `NoMatch` — the reader returned bytes, but no signature and no
+  printable-ASCII fallback applied.
+- `ReaderError(e)` — the reader itself failed; `e` is preserved
+  unchanged.
+- `UnknownExtension(_)` — only emitted by extension/filename helpers,
+  not the reader API.
+
+```gleam
+import gleam/io
+import mimetype
+
+pub fn classify(reader) {
+  case mimetype.detect_reader_strict(reader, 3072) {
+    Ok(mime) -> io.println(mimetype.to_string(mime))
+    Error(mimetype.EmptyInput) -> io.println("empty source")
+    Error(mimetype.NoMatch) -> io.println("unrecognised content")
+    Error(mimetype.ReaderError(reason)) -> io.debug(reason)
+    Error(mimetype.UnknownExtension(_)) -> Nil
+  }
+}
+```
+
 ## Supported magic-number formats
 
 `detect/1` currently recognizes many common MIME types, including:


### PR DESCRIPTION
## Summary

Adds a dedicated "Reader-based detection" guide to the README so users can adopt `detect_reader` / `detect_reader_strict` without reverse-engineering the wrapper shape from the doc comments.

Closes #75.

## Changes

A new section between "Usage" and "Supported magic-number formats" with five subsections:

- **Reader contract** — spells out the `fn(Int) -> Result(BitArray, e)` shape, the "called once with a byte budget" guarantee, the "fewer bytes than requested means EOF" semantics, and the role of the generic `read_error` type parameter.
- **In-memory adapter** — a runnable snippet showing the simplest case (bytes already in hand, ignore the limit argument).
- **BEAM file prefix reader** — sketches the pattern using a `read_prefix(path, limit)` helper so it composes with any first-party file-IO library on Erlang. Notes how the `EmptyInput` and `ReaderError(e)` outcomes flow through.
- **JavaScript browser adapter** — explains that `File` / `Blob` / `ReadableStream` reads are async and therefore cannot satisfy the synchronous Reader contract directly. The recommended pattern is to await the prefix once and pass it to `detect`, not to fabricate a sync reader. Includes a Gleam pseudo-code snippet that calls a tiny FFI helper.
- **Strict variants and error handling** — enumerates the four `DetectionError` constructors and shows a `case` that distinguishes them.

## Design Decisions

- **README-only, no `examples/` directory** — keeping the snippets next to the rest of the API guide makes them discoverable for the people most likely to need them (someone reading hexdocs or the GitHub front page). A separate examples tree adds maintenance load without improving discoverability.
- **No new runtime dependency on a file-IO library** — the BEAM example uses a `read_prefix` placeholder rather than hard-coding `simplifile` or another upstream package. That keeps the gleam.toml graph clean and lets users pick whatever IO layer fits their app.
- **Honest about the async/sync split on JavaScript** — the Reader signature is synchronous by design. Documenting "await first, then `detect`" is more useful than fabricating a faux-async wrapper that would not actually work.

## Limitations

- The BEAM and JavaScript snippets reference helper functions (`read_prefix`, `read_blob_prefix`) that the user must supply via their preferred IO / FFI layer. The README is explicit about this rather than shipping a mandatory adapter.
