### PR TITLE
docs(readme): generate supported-format section from signature table (#76)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,15 @@ jobs:
       - name: Test
         run: just test-${{ matrix.target }}
 
+  readme-up-to-date:
+    name: README supported-format section matches signature table
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v3
+      - name: Verify README is in sync with magic.gleam
+        run: just readme-check
+
   mime-db-up-to-date:
     name: Generated MIME-DB matches script output
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -208,15 +208,116 @@ pub fn classify(reader) {
 
 ## Supported magic-number formats
 
-`detect/1` currently recognizes many common MIME types, including:
+<!-- BEGIN_SUPPORTED_FORMATS -->
+`detect/1` recognises the following MIME types from byte-level
+signatures or structural sniffs near the start of the input. This
+list is generated from `src/mimetype/internal/magic.gleam` by
+`scripts/generate_supported_formats.sh` — do not edit it by hand;
+re-run `just generate-readme` after adding or removing a signature.
 
-- Archive and container formats: `application/zip`, `application/gzip`, `application/x-bzip2`, `application/x-xz`, `application/x-7z-compressed`, `application/x-rar-compressed`, `application/vnd.ms-cab-compressed`, `application/x-tar`, `application/zstd`
-- Documents and data formats: `application/pdf`, `application/vnd.sqlite3`, `application/vnd.apache.parquet`
-- ZIP-derived document formats: `application/epub+zip`, `application/vnd.openxmlformats-officedocument.wordprocessingml.document`, `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`, `application/vnd.openxmlformats-officedocument.presentationml.presentation`, `application/vnd.oasis.opendocument.text`, `application/vnd.oasis.opendocument.spreadsheet`, `application/vnd.oasis.opendocument.presentation`, `application/java-archive`, `application/vnd.android.package-archive`
-- Runtime and transport formats: `application/ogg`, `application/wasm`, `application/x-elf`
-- Audio formats: `audio/wav`, `audio/aiff`, `audio/mpeg`, `audio/flac`, `audio/midi`, `audio/mp4`
-- Image formats: `image/png`, `image/jpeg`, `image/gif`, `image/bmp`, `image/tiff`, `image/x-icon`, `image/webp`, `image/avif`, `image/heic`
-- Video formats: `video/x-msvideo`, `video/webm`, `video/quicktime`, `video/mp4`
+### Application formats
+
+- `application/epub+zip`
+- `application/gzip`
+- `application/java-archive`
+- `application/json`
+- `application/msword`
+- `application/ogg`
+- `application/pdf`
+- `application/vnd.android.package-archive`
+- `application/vnd.apache.parquet`
+- `application/vnd.ms-asf`
+- `application/vnd.ms-cab-compressed`
+- `application/vnd.ms-excel`
+- `application/vnd.ms-fontobject`
+- `application/vnd.ms-powerpoint`
+- `application/vnd.oasis.opendocument.presentation`
+- `application/vnd.oasis.opendocument.spreadsheet`
+- `application/vnd.oasis.opendocument.text`
+- `application/vnd.openxmlformats-officedocument.presentationml.presentation`
+- `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`
+- `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
+- `application/vnd.sqlite3`
+- `application/wasm`
+- `application/x-7z-compressed`
+- `application/x-archive`
+- `application/x-bzip2`
+- `application/x-compress`
+- `application/x-deflate`
+- `application/x-elf`
+- `application/x-lz4`
+- `application/x-lzh-compressed`
+- `application/x-lzip`
+- `application/x-ole-storage`
+- `application/x-rar-compressed`
+- `application/x-snappy-framed`
+- `application/x-tar`
+- `application/x-xz`
+- `application/zip`
+- `application/zstd`
+
+### Audio formats
+
+- `audio/aac`
+- `audio/ac3`
+- `audio/aiff`
+- `audio/amr`
+- `audio/amr-wb`
+- `audio/flac`
+- `audio/midi`
+- `audio/mp4`
+- `audio/mpeg`
+- `audio/wav`
+
+### Font formats
+
+- `font/collection`
+- `font/otf`
+- `font/ttf`
+- `font/woff`
+- `font/woff2`
+
+### Image formats
+
+- `image/avif`
+- `image/bmp`
+- `image/fits`
+- `image/gif`
+- `image/heic`
+- `image/jp2`
+- `image/jpeg`
+- `image/jxl`
+- `image/png`
+- `image/svg+xml`
+- `image/tiff`
+- `image/vnd.adobe.photoshop`
+- `image/vnd.ms-dds`
+- `image/vnd.radiance`
+- `image/webp`
+- `image/x-exr`
+- `image/x-icon`
+- `image/x-qoi`
+
+### Text formats
+
+- `text/html`
+- `text/plain`
+- `text/plain; charset=utf-16be`
+- `text/plain; charset=utf-16le`
+- `text/plain; charset=utf-32be`
+- `text/plain; charset=utf-32le`
+- `text/plain; charset=utf-8`
+- `text/xml`
+
+### Video formats
+
+- `video/mp4`
+- `video/quicktime`
+- `video/webm`
+- `video/x-flv`
+- `video/x-matroska`
+- `video/x-msvideo`
+<!-- END_SUPPORTED_FORMATS -->
 
 The detector is intentionally shallow: it looks only at fixed
 signatures near the start of the byte stream, plus a small amount of

--- a/justfile
+++ b/justfile
@@ -51,6 +51,12 @@ docs:
 generate-db:
   bash scripts/generate_mime_db.sh
 
+generate-readme:
+  sh scripts/generate_supported_formats.sh
+
+readme-check:
+  sh scripts/generate_supported_formats.sh --check
+
 check: clean
   gleam format --check src/ test/
   gleam check

--- a/scripts/generate_supported_formats.sh
+++ b/scripts/generate_supported_formats.sh
@@ -37,8 +37,8 @@ fi
 # Matches "type/subtype" inside double quotes for the six top-level
 # media types we currently emit.
 extract_mime_types() {
-  grep -oE '"(application|audio|video|image|text|font)/[a-zA-Z0-9.+;=_ -]+"' \
-    "$MAGIC" | sort -u | sed -e 's/^"//' -e 's/"$//'
+  LC_ALL=C grep -oE '"(application|audio|video|image|text|font)/[a-zA-Z0-9.+;=_ -]+"' \
+    "$MAGIC" | LC_ALL=C sort -u | sed -e 's/^"//' -e 's/"$//'
 }
 
 # Print one bullet per MIME type for a given top-level family.

--- a/scripts/generate_supported_formats.sh
+++ b/scripts/generate_supported_formats.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+# generate_supported_formats.sh -- Regenerate the supported-format
+# bullet list inside README.md from the MIME type strings declared in
+# src/mimetype/internal/magic.gleam. The generated content sits
+# between the BEGIN_SUPPORTED_FORMATS / END_SUPPORTED_FORMATS HTML
+# comments. Run with --check to verify the file is in sync without
+# rewriting it (used by CI).
+
+set -eu
+
+MAGIC=src/mimetype/internal/magic.gleam
+README=README.md
+BEGIN_MARKER="<!-- BEGIN_SUPPORTED_FORMATS -->"
+END_MARKER="<!-- END_SUPPORTED_FORMATS -->"
+
+mode=write
+case "${1-}" in
+  --check) mode=check ;;
+  "") ;;
+  *)
+    echo "usage: $0 [--check]" >&2
+    exit 2
+    ;;
+esac
+
+if [ ! -f "$MAGIC" ]; then
+  echo "error: $MAGIC not found (run from the repo root)" >&2
+  exit 1
+fi
+
+if [ ! -f "$README" ]; then
+  echo "error: $README not found (run from the repo root)" >&2
+  exit 1
+fi
+
+# Extract every MIME type literal that appears in the signature table.
+# Matches "type/subtype" inside double quotes for the six top-level
+# media types we currently emit.
+extract_mime_types() {
+  grep -oE '"(application|audio|video|image|text|font)/[a-zA-Z0-9.+;=_ -]+"' \
+    "$MAGIC" | sort -u | sed -e 's/^"//' -e 's/"$//'
+}
+
+# Print one bullet per MIME type for a given top-level family.
+emit_family() {
+  family=$1
+  heading=$2
+  matched=$(extract_mime_types | awk -v f="$family/" 'index($0, f) == 1')
+  if [ -z "$matched" ]; then
+    return
+  fi
+  printf '%s\n\n' "$heading"
+  printf '%s\n' "$matched" | while IFS= read -r mime; do
+    printf -- '- `%s`\n' "$mime"
+  done
+  printf '\n'
+}
+
+# Generate the section body. The order here defines the document
+# layout; alphabetical inside each family.
+generate_body() {
+  cat <<'INTRO'
+`detect/1` recognises the following MIME types from byte-level
+signatures or structural sniffs near the start of the input. This
+list is generated from `src/mimetype/internal/magic.gleam` by
+`scripts/generate_supported_formats.sh` — do not edit it by hand;
+re-run `just generate-readme` after adding or removing a signature.
+
+INTRO
+  emit_family application "### Application formats"
+  emit_family audio       "### Audio formats"
+  emit_family font        "### Font formats"
+  emit_family image       "### Image formats"
+  emit_family text        "### Text formats"
+  emit_family video       "### Video formats"
+}
+
+# Splice the generated body between BEGIN_MARKER and END_MARKER inside
+# README.md, leaving everything else untouched. Uses awk so we don't
+# depend on GNU sed's in-place flag.
+splice_into_readme() {
+  body=$1
+  awk -v begin="$BEGIN_MARKER" -v end="$END_MARKER" -v body="$body" '
+    BEGIN { state = "before" }
+    {
+      if (state == "before") {
+        print
+        if ($0 == begin) {
+          print body
+          state = "inside"
+        }
+        next
+      }
+      if (state == "inside") {
+        if ($0 == end) {
+          print
+          state = "after"
+        }
+        next
+      }
+      print
+    }
+    END {
+      if (state == "before") {
+        print "error: BEGIN_SUPPORTED_FORMATS marker not found" > "/dev/stderr"
+        exit 1
+      }
+      if (state == "inside") {
+        print "error: END_SUPPORTED_FORMATS marker not found" > "/dev/stderr"
+        exit 1
+      }
+    }
+  ' "$README"
+}
+
+body=$(generate_body)
+new_readme=$(splice_into_readme "$body")
+
+if [ "$mode" = "check" ]; then
+  if [ "$new_readme" != "$(cat "$README")" ]; then
+    echo "error: README.md is out of date." >&2
+    echo "Re-run 'just generate-readme' and commit the result." >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+printf '%s\n' "$new_readme" > "$README"


### PR DESCRIPTION
## Summary

Replaces the hand-curated bullet list under "Supported magic-number formats" with content generated from the signature table in `src/mimetype/internal/magic.gleam`. The previous list could drift silently when signatures were added or removed without a coordinated README edit; CI now fails the build whenever the two sources fall out of sync.

Closes #76.

## Changes

- **`scripts/generate_supported_formats.sh`** — new POSIX sh script that extracts every MIME literal from the signature table, deduplicates, groups them by top-level family (Application / Audio / Font / Image / Text / Video), and splices the result between `<!-- BEGIN_SUPPORTED_FORMATS -->` and `<!-- END_SUPPORTED_FORMATS -->` markers in `README.md`. Has two modes: write (default) and `--check` (exits non-zero on drift).
- **`README.md`** — replaces the seven-bucket hand-curated bullet list with the marker-delimited generated section. The intro paragraph and the trailing "intentionally shallow" paragraph remain hand-written, sandwiching the generated body. The list now surfaces every signature in `magic.gleam`, including ones the previous list missed (`application/json`, `application/msword`, `image/svg+xml`, `font/*`, `video/x-flv`, `video/x-matroska`, etc.).
- **`justfile`** — adds two recipes: `just generate-readme` rewrites the README in place, and `just readme-check` runs the script in check mode.
- **`.github/workflows/ci.yml`** — adds a `readme-up-to-date` job that mirrors the existing `mime-db-up-to-date` pattern. Runs `just readme-check` on every push and pull request so contributors see the failure immediately when a `magic.gleam` edit needs a README regeneration.

## Design Decisions

- **POSIX sh + grep + awk, no Gleam runtime** — keeps the script self-contained and CI-fast (the new job does not need to install the BEAM toolchain). The categorisation is pure prefix-matching on the MIME `type/` portion, so it naturally absorbs new signatures.
- **Top-level family grouping (`Application` / `Audio` / `Font` / `Image` / `Text` / `Video`) instead of the previous fine-grained buckets** — the previous "Archive / Documents / ZIP-derived / Runtime" subdivision required manual categorisation that itself drifted from reality. Top-level grouping is derivable purely from the MIME string and stays accurate as new signatures land.
- **Splice via marker comments rather than full-file regeneration** — the surrounding hand-written prose (intro, "intentionally shallow" caveat, Development section, Licensing) stays under human control.

## Test plan

- `just readme-check` exits 0 on the committed state (verified locally).
- `just generate-readme` is idempotent (verified locally).
- New CI job runs on this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * The "Supported magic-number formats" section in README is now automatically generated and comprehensively lists all supported file formats, organized by category.

* **Chores**
  * Added CI checks to enforce README stays synchronized with supported formats.
  * Added tooling to regenerate README when format support changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->