### PR TITLE
fix(parse): reject non-tchar bytes in type/subtype essence per RFC 7230

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Fixed
+- `mimetype.parse/1` now rejects `Content-Type` strings whose
+  `type/subtype` essence contains internal whitespace, control
+  characters, or any other non-`tchar` byte. The previous
+  implementation only checked that both halves were non-empty, so
+  inputs like `"text/ html"`, `"text /html"`, and `"text/ht\tml"`
+  silently produced `Ok(...)` even though RFC 6838 / RFC 7231 §3.1.1.1
+  require both halves to be `token`s (`1*tchar` per RFC 7230 §3.2.6).
+  These inputs now return `Error(InvalidMimeType(input))`. Valid
+  token essences with the printable-ASCII tchar specials
+  (`!#$%&'*+-.^_\`|~`) — e.g. `application/vnd.api+json` — still
+  parse successfully. (#88)
+
 ## [0.12.0] - 2026-05-04
 
 ### Documentation

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -620,8 +620,33 @@ pub fn detect_with_filename_strict(
 
 fn valid_essence(essence: String) -> Bool {
   case string.split_once(essence, on: "/") {
-    Ok(#(t, sub)) -> t != "" && sub != "" && !string.contains(sub, "/")
+    Ok(#(t, sub)) -> valid_token(t) && valid_token(sub)
     Error(Nil) -> False
+  }
+}
+
+/// Check whether `s` is a non-empty `token` per RFC 7230 §3.2.6:
+/// `1*tchar`, where `tchar` is a printable ASCII character that is
+/// neither whitespace, a control character, nor an HTTP separator
+/// (`(` `)` `<` `>` `@` `,` `;` `:` `\` `"` `/` `[` `]` `?` `=` `{` `}`).
+fn valid_token(s: String) -> Bool {
+  use <- bool.guard(when: s == "", return: False)
+  string.to_utf_codepoints(s)
+  |> list.all(fn(cp) { is_tchar(string.utf_codepoint_to_int(cp)) })
+}
+
+fn is_tchar(cp: Int) -> Bool {
+  case cp {
+    // ALPHA
+    cp if cp >= 65 && cp <= 90 -> True
+    cp if cp >= 97 && cp <= 122 -> True
+    // DIGIT
+    cp if cp >= 48 && cp <= 57 -> True
+    // ! # $ % & ' * + - .
+    33 | 35 | 36 | 37 | 38 | 39 | 42 | 43 | 45 | 46 -> True
+    // ^ _ ` | ~
+    94 | 95 | 96 | 124 | 126 -> True
+    _ -> False
   }
 }
 

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -287,6 +287,34 @@ pub fn parameter_of_unmatched_leading_quote_passes_through_test() {
   |> should.equal(Some("\"utf-8"))
 }
 
+pub fn parse_rejects_whitespace_in_type_test() {
+  mimetype.parse("text /html")
+  |> should.equal(Error(mimetype.InvalidMimeType("text /html")))
+}
+
+pub fn parse_rejects_whitespace_in_subtype_prefix_test() {
+  mimetype.parse("text/ html")
+  |> should.equal(Error(mimetype.InvalidMimeType("text/ html")))
+}
+
+pub fn parse_rejects_whitespace_inside_subtype_test() {
+  mimetype.parse("text/ht ml")
+  |> should.equal(Error(mimetype.InvalidMimeType("text/ht ml")))
+}
+
+pub fn parse_rejects_control_character_in_essence_test() {
+  mimetype.parse("text/ht\tml")
+  |> should.equal(Error(mimetype.InvalidMimeType("text/ht\tml")))
+}
+
+pub fn parse_accepts_valid_token_essence_test() {
+  // Tokens with all the printable-ASCII tchar specials must still pass.
+  let assert Ok(mt) = mimetype.parse("application/vnd.api+json")
+  mt
+  |> mimetype.essence_of
+  |> should.equal("application/vnd.api+json")
+}
+
 pub fn family_predicates_use_essence_test() {
   mimetype.is_image(mt("IMAGE/PNG; version=1"))
   |> should.equal(True)


### PR DESCRIPTION
## Summary

`mimetype.parse/1` accepted `Content-Type` strings whose `type/subtype` essence contained whitespace or control characters (e.g. `parse(\"text/ html\")` returned `Ok(...)`), violating RFC 6838 / RFC 7231 §3.1.1.1, which require both halves to be `token`s as defined in RFC 7230 §3.2.6 (`1*tchar`).

## Changes

- `src/mimetype.gleam`: extend `valid_essence/1` to validate each half of the essence against the `tchar` grammar via the new `valid_token/1` and `is_tchar/1` helpers. The old `t != \"\" && sub != \"\" && !string.contains(sub, \"/\")` check is subsumed (an empty half is not a valid `1*tchar`; a `/` is not in the tchar alphabet).
- `test/mimetype_test.gleam`: five new regressions — three whitespace placements (`\"text /html\"`, `\"text/ html\"`, `\"text/ht ml\"`), one control character (`\"text/ht\\tml\"`), and one positive case ensuring the printable-ASCII tchar specials in `application/vnd.api+json` still parse cleanly.
- `CHANGELOG.md`: \`Unreleased > Fixed\` entry.

## Design Decisions

- Used a `case` with codepoint guards for `is_tchar` (`>= 65 && <= 90`, etc.) rather than building a `Set(Int)` lookup. The five-way guard is small enough that the lookup table would be more code, not less, and `string.to_utf_codepoints` already iterates once.
- Kept the failure mode as `Error(InvalidMimeType(input))` — same variant the caller would see for any other essence-shape failure — rather than introducing a new `InvalidToken` variant. The RFC distinction between \"missing slash\" and \"non-token half\" is internal; consumers only need to know the input is malformed.

Closes #88