### PR TITLE
fix(parse): make parameter split quoted-string aware per RFC 7230

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## [Unreleased]
 
 ### Fixed
+- `mimetype.parse/1` is now quoted-string-aware when splitting
+  parameters: a `;` (or `=`) inside a `"..."` value is preserved as
+  part of the value instead of being treated as a parameter separator.
+  Previously, `parse("application/json; description=\"a; b\"; charset=utf-8")`
+  truncated `description` to `"a` and parsed the rest of the
+  quoted-string as further top-level parameters, violating
+  RFC 7230 §3.2.6 which permits `;` inside `qdtext`. The new splitter
+  is also `\\`-escape aware so values like `"a\"b; c"` round-trip.
+  This is a strict superset of the unquoting fix in #69. (#89)
 - `mimetype.parse/1` now rejects `Content-Type` strings whose
   `type/subtype` essence contains internal whitespace, control
   characters, or any other non-`tchar` byte. The previous

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -119,7 +119,7 @@ pub const default_detection_limit = 3072
 pub fn parse(input: String) -> Result(MimeType, ParseError) {
   let trimmed = string.trim(input)
   use <- bool.guard(when: trimmed == "", return: Error(EmptyMimeType))
-  case string.split(trimmed, on: ";") {
+  case split_on_unquoted_semicolons(trimmed) {
     [] -> Error(EmptyMimeType)
     [head, ..rest] -> {
       let essence_value = head |> string.trim |> string.lowercase
@@ -617,6 +617,39 @@ pub fn detect_with_filename_strict(
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+/// Split on top-level `;` while keeping `;` characters that appear
+/// inside an RFC 7230 §3.2.6 quoted-string (`"..."`) attached to the
+/// surrounding value. Backslash escapes (`\"`, `\\`, `\;` etc.) within
+/// a quoted-string are honoured so the next character does not toggle
+/// the quote state.
+fn split_on_unquoted_semicolons(s: String) -> List(String) {
+  do_split_semis(s, "", [], False, False)
+  |> list.reverse
+}
+
+fn do_split_semis(
+  remaining: String,
+  current: String,
+  acc: List(String),
+  in_quote: Bool,
+  escape: Bool,
+) -> List(String) {
+  case string.pop_grapheme(remaining) {
+    Error(Nil) -> [current, ..acc]
+    Ok(#(g, rest)) ->
+      case escape, g, in_quote {
+        True, _, _ -> do_split_semis(rest, current <> g, acc, in_quote, False)
+        False, "\\", True ->
+          do_split_semis(rest, current <> g, acc, in_quote, True)
+        False, "\"", _ ->
+          do_split_semis(rest, current <> g, acc, !in_quote, False)
+        False, ";", False ->
+          do_split_semis(rest, "", [current, ..acc], False, False)
+        False, _, _ -> do_split_semis(rest, current <> g, acc, in_quote, False)
+      }
+  }
+}
 
 fn valid_essence(essence: String) -> Bool {
   case string.split_once(essence, on: "/") {

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -315,6 +315,44 @@ pub fn parse_accepts_valid_token_essence_test() {
   |> should.equal("application/vnd.api+json")
 }
 
+pub fn parse_keeps_semicolon_inside_quoted_value_test() {
+  let assert Ok(mt) =
+    mimetype.parse("application/json; description=\"a; b\"; charset=utf-8")
+  mt
+  |> mimetype.parameter_of("description")
+  |> should.equal(Some("a; b"))
+  mt
+  |> mimetype.parameter_of("charset")
+  |> should.equal(Some("utf-8"))
+}
+
+pub fn parse_keeps_equals_inside_quoted_value_test() {
+  let assert Ok(mt) = mimetype.parse("text/plain; key=\"k=v\"")
+  mt
+  |> mimetype.parameter_of("key")
+  |> should.equal(Some("k=v"))
+}
+
+pub fn parse_quoted_string_with_escaped_quote_test() {
+  let assert Ok(mt) = mimetype.parse("text/plain; key=\"a\\\"b; c\"")
+  mt
+  |> mimetype.parameter_of("key")
+  |> should.equal(Some("a\"b; c"))
+}
+
+pub fn parse_unquoted_value_split_unchanged_test() {
+  // Sanity: previously-correct, fully unquoted parameter lists must
+  // keep parsing as before — the new splitter is only special inside
+  // quoted-strings.
+  let assert Ok(mt) = mimetype.parse("text/html; charset=utf-8; boundary=---")
+  mt
+  |> mimetype.parameter_of("charset")
+  |> should.equal(Some("utf-8"))
+  mt
+  |> mimetype.parameter_of("boundary")
+  |> should.equal(Some("---"))
+}
+
 pub fn family_predicates_use_essence_test() {
   mimetype.is_image(mt("IMAGE/PNG; version=1"))
   |> should.equal(True)


### PR DESCRIPTION
## Summary

`mimetype.parse/1` previously used `string.split(_, on: \";\")` unconditionally, so a `;` inside a quoted-string parameter value (legal per RFC 7230 §3.2.6 `qdtext`) was treated as a parameter separator. `parse(\"application/json; description=\\\"a; b\\\"; charset=utf-8\")` truncated `description` to `\"a` and re-parsed the remainder as fresh parameters. Strict superset of the unquoting fix in #69.

## Changes

- `src/mimetype.gleam`:
  - Replace `string.split(trimmed, on: \";\")` in `parse/1` with a new `split_on_unquoted_semicolons/1` helper.
  - Helper is a small grapheme-walking state machine with two flags (`in_quote`, `escape`). Inside a `\"...\"` value the `;`/`=` characters are preserved verbatim; backslash escapes (`\\\"`, `\\\\`, `\;` etc.) are also honoured so the next byte does not toggle the quote state.
- `test/mimetype_test.gleam`: four new regressions —
  - `;` inside quoted value preserved + sibling parameter still parsed,
  - `=` inside quoted value preserved,
  - `\\\"` escape inside quoted value preserved,
  - sanity check that fully unquoted parameter lists still parse identically.
- `CHANGELOG.md`: \`Unreleased > Fixed\` entry referencing #89 and #69.

## Design Decisions

- **Wrote a tiny state machine, not a regex / lexer split.** The machine has only four cases and matches the project's existing style (`unescape_quoted/2` uses the same shape). Pulling in a regex dependency for a four-case scanner would be heavier.
- **Backslash escapes only apply inside `in_quote=True`.** RFC 7230 only defines `quoted-pair` inside `quoted-string`; a top-level `\\` is a literal byte. Matches `unescape_quoted`.
- **Top-level `=` was not made special.** `=` is the parameter separator, but it only matters per-parameter, not per-list. The existing `string.split_once(seg, on: \"=\")` inside `parse_parameters` runs after our quoted-aware split, so a quoted `=` already arrives in the right segment and is preserved by `unquote_value`.

Closes #89