### PR TITLE
chore(release): prepare v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-06
+
 ### Fixed
 - `mimetype.parse/1` is now quoted-string-aware when splitting
   parameters: a `;` (or `=`) inside a `"..."` value is preserved as

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "mimetype"
-version = "0.12.0"
+version = "0.13.0"
 description = "MIME type lookup and magic-number detection for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "mimetype" }


### PR DESCRIPTION
### Fixed
- `mimetype.parse/1` is now quoted-string-aware when splitting
  parameters: a `;` (or `=`) inside a `"..."` value is preserved as
  part of the value instead of being treated as a parameter separator.
  Previously, `parse("application/json; description=\"a; b\"; charset=utf-8")`
  truncated `description` to `"a` and parsed the rest of the
  quoted-string as further top-level parameters, violating
  RFC 7230 §3.2.6 which permits `;` inside `qdtext`. The new splitter
  is also `\\`-escape aware so values like `"a\"b; c"` round-trip.
  This is a strict superset of the unquoting fix in #69. (#89)
- `mimetype.parse/1` now rejects `Content-Type` strings whose
  `type/subtype` essence contains internal whitespace, control
  characters, or any other non-`tchar` byte. The previous
  implementation only checked that both halves were non-empty, so
  inputs like `"text/ html"`, `"text /html"`, and `"text/ht\tml"`
  silently produced `Ok(...)` even though RFC 6838 / RFC 7231 §3.1.1.1
  require both halves to be `token`s (`1*tchar` per RFC 7230 §3.2.6).
  These inputs now return `Error(InvalidMimeType(input))`. Valid
  token essences with the printable-ASCII tchar specials
  (`!#$%&'*+-.^_\`|~`) — e.g. `application/vnd.api+json` — still
  parse successfully. (#88)
