### PR TITLE
fix(mimetype): quote token-illegal parameter values in to_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Fixed
+- `mimetype.to_string` is now round-trippable through `parse/1` for
+  every parameter value. Previously, values that contained a
+  token-illegal character (whitespace, `;`, `,`, `"`, `\`, `=`, etc.)
+  were emitted unquoted, so a value like `"a;b"` came out as
+  `payload=a;b` and the next `parse/1` split at the literal `;`,
+  losing `";b"`. The serialiser now applies RFC 7230 §3.2.6
+  quoted-string rules: token-valid values pass through unchanged
+  (e.g. `charset=utf-8`), and anything else — including the empty
+  string — is wrapped in `"..."` with inner `"` and `\`
+  backslash-escaped. This is the symmetric counterpart of the
+  existing `unquote_value` parser path, so the round-trip property
+  documented in `to_string`'s docstring now actually holds. (#93)
+
 ## [0.13.0] - 2026-05-06
 
 ### Fixed

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -136,6 +136,13 @@ pub fn parse(input: String) -> Result(MimeType, ParseError) {
 /// always normalises whitespace ("`type/subtype; key=value`" with a
 /// single space after each semicolon) and is round-trippable through
 /// `parse/1`.
+///
+/// Parameter values that are not a valid `token` per RFC 7230 §3.2.6
+/// (including the empty string and any value containing whitespace,
+/// `;`, `,`, `"`, etc.) are wrapped in a quoted-string with inner
+/// `"` and `\` backslash-escaped. Token-valid values pass through
+/// unchanged so the common case (`charset=utf-8`, `boundary=abc123`)
+/// stays unquoted.
 pub fn to_string(mt: MimeType) -> String {
   let MimeType(essence_value, parameters) = mt
   case parameters {
@@ -145,7 +152,7 @@ pub fn to_string(mt: MimeType) -> String {
         parameters
         |> list.map(fn(p) {
           let #(k, v) = p
-          k <> "=" <> v
+          k <> "=" <> quote_value(v)
         })
         |> string.join("; ")
       essence_value <> "; " <> serialised_parameters
@@ -698,6 +705,28 @@ fn parse_parameters(segments: List(String)) -> List(#(String, String)) {
       Error(Nil) -> Error(Nil)
     }
   })
+}
+
+/// Wrap a parameter value for serialisation per RFC 7230 §3.2.6.
+///
+/// Values that satisfy `valid_token` are returned unchanged so the
+/// common `charset=utf-8` shape stays terse. Anything else — including
+/// the empty string, whitespace, `;`, `,`, and any other token-illegal
+/// character — is wrapped in `"..."` with inner `"` and `\` escaped
+/// with a leading backslash. The result round-trips through
+/// `unquote_value` and therefore through `parse/1`.
+fn quote_value(value: String) -> String {
+  use <- bool.guard(when: valid_token(value), return: value)
+  "\"" <> escape_quoted(value, "") <> "\""
+}
+
+fn escape_quoted(remaining: String, acc: String) -> String {
+  case string.pop_grapheme(remaining) {
+    Error(Nil) -> acc
+    Ok(#("\"", rest)) -> escape_quoted(rest, acc <> "\\\"")
+    Ok(#("\\", rest)) -> escape_quoted(rest, acc <> "\\\\")
+    Ok(#(other, rest)) -> escape_quoted(rest, acc <> other)
+  }
 }
 
 /// Unwrap a parameter value from RFC 7230 §3.2.6 quoted-string form.

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -272,6 +272,65 @@ pub fn parse_then_to_string_then_parse_quoted_value_round_trips_test() {
   |> should.equal(Some("utf-8"))
 }
 
+pub fn to_string_quotes_value_with_semicolon_test() {
+  // #93: parameter values containing `;` must be quoted on output, or
+  // a re-parse would split the value at the `;`.
+  let assert Ok(mt1) = mimetype.parse("application/json; payload=\"a;b\"")
+  let serialised = mimetype.to_string(mt1)
+  let assert Ok(mt2) = mimetype.parse(serialised)
+  mimetype.parameter_of(mt2, "payload")
+  |> should.equal(Some("a;b"))
+}
+
+pub fn to_string_quotes_value_with_whitespace_test() {
+  // RFC 7230 token disallows whitespace; a value with a space must be
+  // wrapped in quoted-string so the round-trip preserves it.
+  let assert Ok(mt1) = mimetype.parse("application/json; tag=\"hello world\"")
+  let serialised = mimetype.to_string(mt1)
+  let assert Ok(mt2) = mimetype.parse(serialised)
+  mimetype.parameter_of(mt2, "tag")
+  |> should.equal(Some("hello world"))
+}
+
+pub fn to_string_escapes_inner_quote_test() {
+  // Inner `"` in a value must be backslash-escaped so the closing `"`
+  // delimiter isn't confused with a literal one inside the value.
+  let assert Ok(mt1) = mimetype.parse("application/json; tag=\"a\\\"b\"")
+  let serialised = mimetype.to_string(mt1)
+  let assert Ok(mt2) = mimetype.parse(serialised)
+  mimetype.parameter_of(mt2, "tag")
+  |> should.equal(Some("a\"b"))
+}
+
+pub fn to_string_escapes_inner_backslash_test() {
+  // Inner `\` must be doubled or it would consume the following byte
+  // on re-parse via `unquote_value`.
+  let assert Ok(mt1) = mimetype.parse("application/json; tag=\"a\\\\b\"")
+  let serialised = mimetype.to_string(mt1)
+  let assert Ok(mt2) = mimetype.parse(serialised)
+  mimetype.parameter_of(mt2, "tag")
+  |> should.equal(Some("a\\b"))
+}
+
+pub fn to_string_quotes_empty_parameter_value_test() {
+  // Empty value is not a valid token (`1*tchar`), so it must be
+  // serialised as the empty quoted-string `""`.
+  let assert Ok(mt1) = mimetype.parse("application/json; tag=\"\"")
+  let serialised = mimetype.to_string(mt1)
+  let assert Ok(mt2) = mimetype.parse(serialised)
+  mimetype.parameter_of(mt2, "tag")
+  |> should.equal(Some(""))
+}
+
+pub fn to_string_leaves_token_value_unquoted_test() {
+  // Token-valid values (alphanum + safe punctuation) must pass through
+  // without gaining quotes — the common `charset=utf-8` shape stays
+  // identical to the input.
+  let assert Ok(mt1) = mimetype.parse("text/html; charset=utf-8")
+  mimetype.to_string(mt1)
+  |> should.equal("text/html; charset=utf-8")
+}
+
 pub fn parameter_of_lone_quote_passes_through_test() {
   // A bare `"` (length 1) is malformed per RFC 7230 — pass through
   // unchanged so the parser stays tolerant.


### PR DESCRIPTION
## Summary

`mimetype.to_string` claims its output is round-trippable through
`parse/1`, but it serialised parameter values by raw concatenation
(`k <> "=" <> v`), so a value containing `;` (or whitespace, `,`, `"`,
`\`, …) re-split when re-parsed. Issue #93 reported a clean reproducer:
`payload="a;b"` went out as `payload=a;b` and came back as `a`, losing
`";b"`. This PR makes the serialiser RFC 7230 §3.2.6 compliant so the
documented contract actually holds.

## Changes

- `src/mimetype.gleam`: new private helpers `quote_value` and
  `escape_quoted`. `to_string` now wraps every parameter value
  through `quote_value`, which returns token-valid values unchanged
  and otherwise emits a quoted-string (`"..."`) with inner `"` and
  `\` backslash-escaped. The existing `unquote_value` parser path is
  the symmetric inverse, so what `to_string` writes, `parse/1` reads.
  The docstring on `to_string` is expanded to spell out the rule.
- `test/mimetype_test.gleam`: six new round-trip tests covering
  token-valid values (no quoting added), values with `;`, whitespace,
  inner `"`, inner `\`, and the empty string.
- `CHANGELOG.md`: `[Unreleased] / Fixed` entry.

## Design Decisions

- Symmetric inverse of `unquote_value`. The parser already strips
  surrounding `"` and decodes `\X → X`. Adding the matching emitter
  alongside it (rather than a different escape strategy) means there
  is exactly one shape per value — easier to audit and impossible to
  drift out of sync.
- Token-valid values stay unquoted. `charset=utf-8`, `boundary=abc123`,
  and similar common cases would be ugly with mandatory quoting and
  every existing test asserting the unquoted shape would break.
  `valid_token` already encodes the right predicate, so reusing it
  costs nothing.
- Empty string round-trips as `""`. An empty value is not a valid
  `1*tchar` token, so the serialiser emits the literal empty
  quoted-string. `unquote_value` already handles `""` correctly.

## Limitations

- This is technically a wire-format change for callers that compare
  `to_string` output byte-for-byte against a fixed string with a
  token-illegal value. As Issue #93 notes, the previous output was
  RFC-invalid for those cases — no spec-conforming consumer can have
  been depending on it — so this ships as a non-breaking fix in the
  next minor release.

Closes #93


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed MIME type parameter value serialization to properly quote and escape special characters, ensuring correct round-trip parsing. Parameter values containing semicolons, whitespace, quotes, backslashes, and empty values are now handled per RFC 7230 standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->