### PR TITLE
docs(mimetype): pin parameter_of behaviour (duplicates, case, OWS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Documentation
+- `mimetype.parameter_of` docstring now pins three previously
+  under-documented behaviours that callers had to discover by
+  experiment: (a) when an input string carries the same parameter
+  name twice, the first occurrence wins; (b) lookup keys are
+  matched case-insensitively because both the lookup key and the
+  stored names are lowercased at construction time; (c) whitespace
+  *around* a token value is stripped, but whitespace *inside* a
+  quoted-string is preserved verbatim. Four matching regression
+  tests in `test/mimetype_test.gleam` lock the behaviour against
+  silent regressions, and the README cross-links the docstring as
+  the authoritative reference for parameter semantics. (#94)
+
 ### Fixed
 - `mimetype.to_string` is now round-trippable through `parse/1` for
   every parameter value. Previously, values that contained a

--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ The full surface returns an opaque `MimeType`. Use `mimetype.to_string`
 to serialise for an HTTP header; use `mimetype.parse` to construct one
 from a wire-format string. Inspect with `essence_of`, `parameter_of`,
 `charset_of_type`, `is_image`, `is_a`, and the rest of the predicate /
-accessor family.
+accessor family. The `parameter_of` docstring pins the rules for
+duplicate names (first wins), case-insensitive lookup, and value
+whitespace handling — consult it before building anything that round-
+trips parameters.
 
 ```gleam
 import gleam/option.{Some}

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -173,8 +173,24 @@ pub fn essence_of(mt: MimeType) -> String {
 
 /// Look up a parameter value on a `MimeType`. Returns `None` for
 /// missing parameters and for an empty / whitespace-only `key`.
-/// Parameter names are matched case-insensitively; values are
-/// returned with surrounding whitespace stripped but case preserved.
+///
+/// ## Parameter handling
+///
+/// - **Duplicate names**: when the input string carries the same
+///   parameter name twice (e.g. `text/plain; charset=utf-8; charset=ascii`),
+///   the *first* occurrence wins. RFC 7231 does not define a winner,
+///   so this lookup commits to a deterministic rule rather than letting
+///   the result depend on `parse/1`'s storage order.
+/// - **Case-insensitive lookup**: both the `key` argument and the
+///   stored parameter names are normalised to lowercase, so
+///   `parameter_of(parse("text/plain; CHARSET=UTF-8"), "CharSet")`
+///   returns `Some("UTF-8")`. Names are case-insensitive per the spec;
+///   values are returned with their original case preserved.
+/// - **Whitespace on values**: surrounding whitespace is stripped from
+///   the stored value (`text/plain; charset=  utf-8` → `Some("utf-8")`).
+///   Whitespace *inside* a quoted-string is part of the value and is
+///   preserved verbatim (`text/plain; description="hello world"` →
+///   `Some("hello world")`).
 pub fn parameter_of(mt: MimeType, key: String) -> Option(String) {
   let requested = key |> string.trim |> string.lowercase
   use <- bool.lazy_guard(when: requested == "", return: fn() { None })

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -331,6 +331,44 @@ pub fn to_string_leaves_token_value_unquoted_test() {
   |> should.equal("text/html; charset=utf-8")
 }
 
+pub fn parameter_of_duplicate_name_first_wins_test() {
+  // #94 (a): when the input carries the same parameter name twice,
+  // `parameter_of` returns the FIRST occurrence. Pinned in the
+  // docstring; this test guards against a future regression flipping
+  // the rule to "last wins" silently.
+  let assert Ok(mt) = mimetype.parse("text/plain; charset=utf-8; charset=ascii")
+  mimetype.parameter_of(mt, "charset")
+  |> should.equal(Some("utf-8"))
+}
+
+pub fn parameter_of_lookup_key_case_insensitive_test() {
+  // #94 (b): the lookup key is lowercased before matching, and stored
+  // names are also lowercased at parse time, so a mixed-case key
+  // resolves a mixed-case stored name. Value case is preserved.
+  let assert Ok(mt) = mimetype.parse("text/plain; CHARSET=UTF-8")
+  mimetype.parameter_of(mt, "CharSet")
+  |> should.equal(Some("UTF-8"))
+}
+
+pub fn parameter_of_strips_surrounding_whitespace_on_value_test() {
+  // #94 (c): whitespace AROUND a token value is stripped at parse
+  // time. `string.trim` is symmetric, so leading and trailing
+  // whitespace are both removed.
+  let assert Ok(mt) = mimetype.parse("text/plain; charset=  utf-8  ")
+  mimetype.parameter_of(mt, "charset")
+  |> should.equal(Some("utf-8"))
+}
+
+pub fn parameter_of_preserves_internal_whitespace_in_quoted_value_test() {
+  // #94 (c, continued): whitespace INSIDE a quoted-string is part of
+  // the value and must NOT be collapsed or trimmed. This complements
+  // the trimming rule above — the two together define what
+  // "surrounding whitespace stripped" means.
+  let assert Ok(mt) = mimetype.parse("text/plain; description=\"hello world\"")
+  mimetype.parameter_of(mt, "description")
+  |> should.equal(Some("hello world"))
+}
+
 pub fn parameter_of_lone_quote_passes_through_test() {
   // A bare `"` (length 1) is malformed per RFC 7230 — pass through
   // unchanged so the parser stays tolerant.


### PR DESCRIPTION
## Summary

`mimetype.parameter_of` had three observable behaviours that were
correct in the implementation but invisible in the docs. Issue #94
asked for each one to be pinned in the docstring and locked behind a
regression test so a future refactor can't silently flip them.

## Changes

- `src/mimetype.gleam`: `parameter_of` docstring grows a "Parameter
  handling" section spelling out (a) duplicate name → first wins,
  (b) lookup is case-insensitive on both sides because storage is
  lowercased at parse time, (c) value's *surrounding* whitespace is
  stripped while *inside-quoted-string* whitespace is preserved.
- `test/mimetype_test.gleam`: four regression tests, one per
  behaviour (the whitespace rule needs two — trim around, preserve
  inside).
- `README.md`: the "Other API entry points" paragraph now points
  callers at the docstring as the authoritative reference for
  parameter semantics.
- `CHANGELOG.md`: `[Unreleased] / Documentation` entry.

## Design Decisions

- Pin the rules, do not change them. The implementation is already
  consistent with what the docstring will now say; this PR ratifies
  the existing behaviour rather than introducing a new one. RFC 7231
  does not pick a duplicate-name winner, so the "first wins" rule is
  documented as a deliberate library choice rather than a spec
  requirement.
- Two whitespace tests rather than one. "Surrounding whitespace
  stripped" is ambiguous on its own — it could be read as "all
  whitespace stripped". Splitting into a trim-around test and a
  preserve-inside-quoted-string test makes the boundary explicit and
  matches the docstring's two-clause phrasing.
- README cross-link, not a duplication of the rules. Spelling them
  out twice would invite drift; pointing at the docstring keeps a
  single source of truth.

Closes #94
