### PR TITLE
chore(release): prepare v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-07
+
 ### Changed
 - **internal**: `src/mimetype.gleam` is now a thin facade. The
   per-domain logic that previously lived in the same 870-line file —

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "mimetype"
-version = "0.13.0"
+version = "0.14.0"
 description = "MIME type lookup and magic-number detection for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "mimetype" }


### PR DESCRIPTION
### Changed
- **internal**: `src/mimetype.gleam` is now a thin facade. The
  per-domain logic that previously lived in the same 870-line file —
  RFC 7230 / RFC 6838 wire-format parsing and serialisation,
  extension / filename lookup, family predicates and ancestor
  chains, and byte-signature detection — has moved to dedicated
  modules under `src/mimetype/internal/`: `parse.gleam`,
  `lookup.gleam`, `predicates.gleam`, and `detect.gleam`. The facade
  retains the `MimeType` opaque type, the public error types
  (`ParseError`, `DetectionError`, `Reader`), and a one-line wrapper
  for every `pub fn`. **No public API change** — every `mimetype.foo`
  call resolves identically. Internal-module imports are not part of
  the public contract; the existing `internal_modules` declaration
  in `gleam.toml` already documents that. CONTRIBUTING.md is
  extended with a "where to put new detection rules / new parser
  logic" section. (#95)

### Documentation
- `mimetype.parameter_of` docstring now pins three previously
  under-documented behaviours that callers had to discover by
  experiment: (a) when an input string carries the same parameter
  name twice, the first occurrence wins; (b) lookup keys are
  matched case-insensitively because both the lookup key and the
  stored names are lowercased at construction time; (c) whitespace
  *around* a token value is stripped, but whitespace *inside* a
  quoted-string is preserved verbatim. Four matching regression
  tests in `test/mimetype_test.gleam` lock the behaviour against
  silent regressions, and the README cross-links the docstring as
  the authoritative reference for parameter semantics. (#94)

### Fixed
- `mimetype.to_string` is now round-trippable through `parse/1` for
  every parameter value. Previously, values that contained a
  token-illegal character (whitespace, `;`, `,`, `"`, `\`, `=`, etc.)
  were emitted unquoted, so a value like `"a;b"` came out as
  `payload=a;b` and the next `parse/1` split at the literal `;`,
  losing `";b"`. The serialiser now applies RFC 7230 §3.2.6
  quoted-string rules: token-valid values pass through unchanged
  (e.g. `charset=utf-8`), and anything else — including the empty
  string — is wrapped in `"..."` with inner `"` and `\`
  backslash-escaped. This is the symmetric counterpart of the
  existing `unquote_value` parser path, so the round-trip property
  documented in `to_string`'s docstring now actually holds. (#93)
