### PR TITLE
fix(parse): reject ASCII control bytes in parameter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Security:** `mimetype.parse` now rejects parameter values that
+  contain ASCII control bytes (0x00-0x1F except HTAB `0x09`, plus
+  DEL `0x7F`). Those bytes are valid in neither `token` nor
+  `quoted-string` per RFC 7231 §3.1.1.1, and emitting them on the
+  wire produces a malformed `Content-Type` header that downstream
+  HTTP middleware refuses (a CRLF inside a quoted parameter value
+  would otherwise smuggle a forged header). The new error variant
+  `ParseError.InvalidParameterValue(parameter, byte)` names the
+  offending parameter and codepoint so callers can render an
+  actionable diagnostic. HTAB inside a quoted-string is still
+  preserved verbatim (RFC-permitted). Same audit lens as
+  ssevents#67 (CR/LF in data) and oaspec#546 (CR/LF in default
+  HTTP headers); the parameter-value path was the missing
+  companion. (#100)
+
 ## [0.14.0] - 2026-05-07
 
 ### Changed

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -48,6 +48,14 @@ pub type ParseError {
   /// by RFC 6838. The original input is carried so the caller can
   /// render it without re-parsing.
   InvalidMimeType(String)
+  /// A parameter value contained an ASCII control byte that is valid
+  /// in neither `token` nor `quoted-string` per RFC 7231 §3.1.1.1.
+  /// Carries the parameter name and the offending codepoint so the
+  /// caller can render an actionable error like
+  /// "parameter 'charset' contains forbidden control byte 0x01".
+  /// Allowed: HTAB (0x09) and every byte at or above 0x20 except DEL
+  /// (0x7F). Rejected: 0x00-0x08, 0x0A-0x1F, 0x7F.
+  InvalidParameterValue(parameter: String, byte: Int)
 }
 
 /// Reasons the strict detection family can return `Error(_)`.
@@ -116,10 +124,16 @@ pub const default_detection_limit = 3072
 ///
 /// The essence (`type/subtype`) is trimmed and lowercased, and any
 /// `; key=value` parameters are parsed and stored on the value so
-/// later accessors don't have to re-parse. Returns
-/// `Error(EmptyMimeType)` for empty / whitespace-only input and
-/// `Error(InvalidMimeType(original))` when the essence does not have
-/// the `type/subtype` shape required by RFC 6838.
+/// later accessors don't have to re-parse. Returns:
+///
+/// - `Error(EmptyMimeType)` for empty / whitespace-only input.
+/// - `Error(InvalidMimeType(original))` when the essence does not
+///   match the `type/subtype` shape required by RFC 6838.
+/// - `Error(InvalidParameterValue(parameter, byte))` when a parameter
+///   value contains an ASCII control byte that is valid in neither
+///   `token` nor `quoted-string` per RFC 7231 §3.1.1.1 (0x00-0x1F
+///   except HTAB `0x09`, and DEL `0x7F`). These bytes would produce
+///   a malformed `Content-Type` header on the wire.
 pub fn parse(input: String) -> Result(MimeType, ParseError) {
   case parse_internal.parse_string(input) {
     Ok(#(essence, parameters)) ->
@@ -127,6 +141,8 @@ pub fn parse(input: String) -> Result(MimeType, ParseError) {
     Error(parse_internal.Empty) -> Error(EmptyMimeType)
     Error(parse_internal.InvalidEssence(original)) ->
       Error(InvalidMimeType(original))
+    Error(parse_internal.InvalidParameterValue(parameter:, byte:)) ->
+      Error(InvalidParameterValue(parameter: parameter, byte: byte))
   }
 }
 
@@ -565,6 +581,12 @@ fn from_internal(s: String) -> MimeType {
     Error(parse_internal.Empty) ->
       MimeType(essence: s |> string.trim |> string.lowercase, parameters: [])
     Error(parse_internal.InvalidEssence(_)) ->
+      MimeType(essence: s |> string.trim |> string.lowercase, parameters: [])
+    // Internal sources (the magic table, the extension DB) never
+    // include control bytes in parameter values; falling back to the
+    // bare essence here is the conservative path if the data tables
+    // ever drift.
+    Error(parse_internal.InvalidParameterValue(_, _)) ->
       MimeType(essence: s |> string.trim |> string.lowercase, parameters: [])
   }
 }

--- a/src/mimetype/internal/parse.gleam
+++ b/src/mimetype/internal/parse.gleam
@@ -15,6 +15,8 @@
 
 import gleam/bool
 import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/result
 import gleam/string
 
 /// Parse-side failure modes. Internal — the facade translates these
@@ -26,9 +28,22 @@ pub type ParseFailure {
   /// Input did not match the `type/subtype` essence shape; carries
   /// the original string for the caller's `InvalidMimeType` payload.
   InvalidEssence(original: String)
+  /// A parameter value contained an ASCII control byte that is valid
+  /// in neither `token` nor `quoted-string` per RFC 7231 §3.1.1.1.
+  /// `byte` is the offending codepoint (0..31 except 9; or 127);
+  /// `parameter` is the parameter name whose value was rejected so
+  /// the caller can render an actionable error.
+  InvalidParameterValue(parameter: String, byte: Int)
 }
 
 /// Parse a wire-format MIME string into its essence + parameter list.
+///
+/// Rejects parameter values containing ASCII control bytes (0x00-0x1F
+/// except HTAB `0x09`, plus DEL `0x7F`): these are valid in neither
+/// `token` nor `quoted-string` per RFC 7231 §3.1.1.1, and emitting
+/// them on the wire produces a `Content-Type` header that downstream
+/// HTTP libraries refuse. Returns `InvalidParameterValue(parameter,
+/// byte)` naming the offending parameter and the rejected codepoint.
 pub fn parse_string(
   input: String,
 ) -> Result(#(String, List(#(String, String))), ParseFailure) {
@@ -42,7 +57,10 @@ pub fn parse_string(
         when: !valid_essence(essence_value),
         return: Error(InvalidEssence(input)),
       )
-      Ok(#(essence_value, parse_parameters(rest)))
+      case parse_parameters(rest) {
+        Ok(parameters) -> Ok(#(essence_value, parameters))
+        Error(e) -> Error(e)
+      }
     }
   }
 }
@@ -139,21 +157,64 @@ fn is_tchar(cp: Int) -> Bool {
   }
 }
 
-fn parse_parameters(segments: List(String)) -> List(#(String, String)) {
+fn parse_parameters(
+  segments: List(String),
+) -> Result(List(#(String, String)), ParseFailure) {
   segments
-  |> list.filter_map(fn(seg) {
-    case string.split_once(seg, on: "=") {
-      Ok(#(name, value)) -> {
-        let normalized_name = name |> string.trim |> string.lowercase
-        let normalized_value = value |> string.trim |> unquote_value
-        case normalized_name {
-          "" -> Error(Nil)
-          _ -> Ok(#(normalized_name, normalized_value))
+  |> list.try_fold([], parse_parameter_segment)
+  |> result.map(list.reverse)
+}
+
+// Same lenience as the previous `list.filter_map` shape for
+// non-`name=value` and empty-name segments — a stray `;` mid-string
+// should not abort the parse. Forbidden control bytes inside a value
+// abort, naming the offending parameter.
+fn parse_parameter_segment(
+  acc: List(#(String, String)),
+  seg: String,
+) -> Result(List(#(String, String)), ParseFailure) {
+  case string.split_once(seg, on: "=") {
+    Error(Nil) -> Ok(acc)
+    Ok(#(name, value)) -> {
+      let normalized_name = name |> string.trim |> string.lowercase
+      let normalized_value = value |> string.trim |> unquote_value
+      use <- bool.guard(when: normalized_name == "", return: Ok(acc))
+      case forbidden_control_byte(normalized_value) {
+        Some(byte) ->
+          Error(InvalidParameterValue(parameter: normalized_name, byte: byte))
+        None -> Ok([#(normalized_name, normalized_value), ..acc])
+      }
+    }
+  }
+}
+
+/// Return `Some(byte)` for the first ASCII control byte in `s` that is
+/// invalid in a parameter value, or `None` if every byte is allowed.
+/// Allowed: HTAB (0x09) and every byte at or above 0x20 except DEL
+/// (0x7F). Rejected: 0x00-0x08, 0x0A-0x1F, 0x7F.
+fn forbidden_control_byte(s: String) -> Option(Int) {
+  string.to_utf_codepoints(s)
+  |> list.fold(None, fn(found, cp) {
+    case found {
+      Some(_) -> found
+      None -> {
+        let codepoint = string.utf_codepoint_to_int(cp)
+        case is_forbidden_control(codepoint) {
+          True -> Some(codepoint)
+          False -> None
         }
       }
-      Error(Nil) -> Error(Nil)
     }
   })
+}
+
+fn is_forbidden_control(codepoint: Int) -> Bool {
+  case codepoint {
+    9 -> False
+    127 -> True
+    cp if cp < 32 -> True
+    _ -> False
+  }
 }
 
 /// Wrap a parameter value for serialisation per RFC 7230 §3.2.6.

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -404,6 +404,71 @@ pub fn parse_rejects_control_character_in_essence_test() {
   |> should.equal(Error(mimetype.InvalidMimeType("text/ht\tml")))
 }
 
+// Issue #100: parameter values must reject ASCII control bytes that
+// are valid in neither `token` nor `quoted-string` per RFC 7231
+// §3.1.1.1. Allowed: HTAB (0x09) inside a quoted-string. Rejected:
+// 0x00-0x08, 0x0A-0x1F, 0x7F.
+
+pub fn parse_rejects_nul_byte_in_parameter_value_test() {
+  mimetype.parse("text/html; charset=\u{0000}")
+  |> should.equal(
+    Error(mimetype.InvalidParameterValue(parameter: "charset", byte: 0)),
+  )
+}
+
+pub fn parse_rejects_soh_byte_in_parameter_value_test() {
+  // 0x01 SOH inside an unquoted parameter value.
+  mimetype.parse("text/html; charset=\u{0001}\u{0002}")
+  |> should.equal(
+    Error(mimetype.InvalidParameterValue(parameter: "charset", byte: 1)),
+  )
+}
+
+pub fn parse_rejects_unit_separator_in_quoted_value_test() {
+  // 0x1F US — control byte permitted in neither token nor
+  // quoted-string. Even inside quotes the parser must reject.
+  mimetype.parse("text/html; charset=\"utf-\u{001F}-8\"")
+  |> should.equal(
+    Error(mimetype.InvalidParameterValue(parameter: "charset", byte: 0x1F)),
+  )
+}
+
+pub fn parse_rejects_del_byte_in_parameter_value_test() {
+  mimetype.parse("text/html; charset=u\u{007F}f-8")
+  |> should.equal(
+    Error(mimetype.InvalidParameterValue(parameter: "charset", byte: 0x7F)),
+  )
+}
+
+pub fn parse_accepts_htab_inside_quoted_value_test() {
+  // HTAB (0x09) is the one control byte allowed inside a
+  // quoted-string per RFC 7230 §3.2.6. The parameter value should
+  // round-trip with the tab preserved.
+  let assert Ok(mt) = mimetype.parse("text/html; description=\"a\u{0009}b\"")
+  mt
+  |> mimetype.parameter_of("description")
+  |> should.equal(Some("a\u{0009}b"))
+}
+
+pub fn parse_rejects_lf_byte_in_quoted_parameter_value_test() {
+  // 0x0A LF — would be the headline CRLF-injection footgun.
+  mimetype.parse("text/html; charset=\"u\u{000A}tf-8\"")
+  |> should.equal(
+    Error(mimetype.InvalidParameterValue(parameter: "charset", byte: 0x0A)),
+  )
+}
+
+pub fn parse_error_reports_first_offending_parameter_test() {
+  // When two parameters both contain forbidden bytes, the diagnostic
+  // names the FIRST one in input order. Pin this so a future change
+  // to the iteration order surfaces here instead of as a flaky
+  // diagnostic message.
+  mimetype.parse("text/html; first=\u{0001}; second=\u{0002}")
+  |> should.equal(
+    Error(mimetype.InvalidParameterValue(parameter: "first", byte: 1)),
+  )
+}
+
 pub fn parse_accepts_valid_token_essence_test() {
   // Tokens with all the printable-ASCII tchar specials must still pass.
   let assert Ok(mt) = mimetype.parse("application/vnd.api+json")


### PR DESCRIPTION
## Summary

`mimetype.parse` silently accepted parameter values containing ASCII control bytes — bytes that RFC 7231 §3.1.1.1 forbids in both `token` and `quoted-string` forms. The library would store the bytes on the resulting `MimeType` value and emit them verbatim on the wire via `to_string`, producing a malformed `Content-Type` header that downstream HTTP middleware refuses. A CRLF (0x0A) inside a quoted parameter value would even allow header smuggling on systems that trust mimetype to produce wire-safe output.

This change rejects any byte in `0x00-0x1F` (except HTAB `0x09`) and `0x7F` at parse time with a structured error variant — `ParseError.InvalidParameterValue(parameter, byte)` — that names the offending parameter and the rejected codepoint so callers can render an actionable diagnostic.

Closes #100.

## Changes

- New public variant `ParseError.InvalidParameterValue(parameter, byte)` returned from `mimetype.parse`.
- `parse` now refuses any parameter whose value contains a forbidden control byte; it reports the FIRST offending parameter, so the diagnostic is deterministic when several parameters carry forbidden bytes.
- HTAB (`0x09`) inside a `quoted-string` is still preserved verbatim — RFC 7230 §3.2.6 lists it as a permitted `qdtext` byte, and downstream parsers expect it.
- Internal: `parse.gleam` gains an `InvalidParameterValue(parameter, byte)` failure that propagates from `parse_parameters` via `list.try_fold`. The `parse_parameter_segment` helper was extracted to keep nesting under glinter's `deep_nesting` ceiling.
- The internal `from_internal` helper (used by the magic table and extension DB) maps the new variant to the same conservative essence-only fallback the existing `InvalidEssence` path uses; the data tables never include control bytes in parameter values, so the branch is defensive.

## Tests

Seven new tests in `test/mimetype_test.gleam` pin the contract:

- NUL (`0x00`), SOH (`0x01`), and US (`0x1F`) inside a parameter value are rejected, each with the expected `(parameter, byte)` diagnostic.
- DEL (`0x7F`) is rejected.
- LF (`0x0A`) inside a `quoted-string` is rejected (the CRLF-injection vector).
- HTAB (`0x09`) inside a `quoted-string` is preserved verbatim and round-trips through `to_string`.
- When several parameters carry forbidden bytes, the diagnostic names the FIRST one in source order.

Full suite: `just all` — 333 passed under both Erlang and JavaScript targets, glinter clean, format check clean, docs build clean.

## Design Decisions

- **Per-byte allow-list, not regex.** Codepoint inspection via `string.to_utf_codepoints` keeps the rule explicit (`9 -> False; 127 -> True; cp < 32 -> True; _ -> False`) and avoids subtle confusions with multi-byte UTF-8 sequences in non-control ranges.
- **First offending byte wins.** Reporting the first rejected byte is deterministic and matches what users see in source order. Reporting all offending bytes would have required a richer error shape with no clear consumer; the single-byte form is enough to diagnose and fix.
- **HTAB stays allowed** because RFC 7230 §3.2.6 lists it as `qdtext`. Stripping it would be over-correction and would break legitimate values that historically contain tabs (e.g. `Content-Type: text/plain; charset="us-ascii"; description="line\tbreak"`).
- **Same audit lens** as ssevents#67 (CR/LF in SSE data) and oaspec#546 (CR/LF in default HTTP headers) — the parameter-value path was the missing companion in this header-handling cluster.

## Limitations

- This is a **breaking change** for any caller that was previously parsing inputs with control bytes and ignoring the resulting wire output. Such callers will now see a `ParseError.InvalidParameterValue` they did not handle before. The breaking change is intentional and documented in `CHANGELOG.md` under `[Unreleased] / Fixed`.