### PR TITLE
docs: drop facade/internal-layout note from public mimetype docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Documentation
+
+- **mimetype** (public module): drop the "facade" paragraph from the
+  top-level `////` doc that leaked the internal layout (referencing
+  `mimetype/internal/*` and "reviewer ergonomics") into the published
+  docs. The split between public surface and internal helpers is an
+  implementation detail and shouldn't show up on hexdocs. (#103)
+
 ## [0.15.0] - 2026-05-07
 
 ### Fixed

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -12,11 +12,6 @@
 //// - magic-number detection, which inspects the leading bytes
 //// - combined helpers, which prefer content-based detection and fall
 ////   back to metadata when the byte signature is unknown
-////
-//// This module is a facade. Per-domain logic — wire-format parsing,
-//// extension/filename lookup, family predicates, and signature
-//// detection — lives under `mimetype/internal/*`. The split is for
-//// reviewer ergonomics; the public surface here is unchanged.
 
 import gleam/bool
 import gleam/list


### PR DESCRIPTION
## Summary
- Removes the paragraph in `src/mimetype.gleam`'s top-level `////` doc that referenced `mimetype/internal/*` and "reviewer ergonomics". That paragraph is an implementation detail about the source layout and shouldn't appear on the published hexdocs page (Louis flagged it in #103).
- Documents the change under `## [Unreleased]` in `CHANGELOG.md`.

## Test plan
- [x] `just all` (format-check + glinter + erlang + javascript checks + tests + docs build) — all green.

Closes #103.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Removed references to internal implementation details from public module documentation to improve clarity of the public API surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->