### PR TITLE
chore(release): prepare v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-05-07
+
 ### Documentation
 
 - **mimetype** (public module): drop the "facade" paragraph from the

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "mimetype"
-version = "0.15.0"
+version = "0.16.0"
 description = "MIME type lookup and magic-number detection for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "mimetype" }


### PR DESCRIPTION
### Documentation

- **mimetype** (public module): drop the "facade" paragraph from the
  top-level `////` doc that leaked the internal layout (referencing
  `mimetype/internal/*` and "reviewer ergonomics") into the published
  docs. The split between public surface and internal helpers is an
  implementation detail and shouldn't show up on hexdocs. (#103)
