### PR TITLE
fix(detect): resolve RTF documents to application/rtf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **detect**: RTF documents (`{\rtf1...`) were misdetected as
+  `text/plain` because every byte in the header is printable ASCII
+  and the magic-byte detector had no rule for them, so the input
+  slid through to the `looks_like_plain_text` heuristic. Add a
+  6-byte signature check (`{\rtf` + ASCII digit) that resolves to
+  `application/rtf`. Closes the security gap where a Word-import
+  endpoint with an `application/rtf`-only allowlist would silently
+  reject valid RTF uploads, and the inverse case where a
+  `text/plain`-permissive endpoint would accept an RTF file with
+  embedded objects/macros. (#106, #107)
+
 ### Added
 
 - Property-based and metamorphic tests using

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ re-run `just generate-readme` after adding or removing a signature.
 - `application/msword`
 - `application/ogg`
 - `application/pdf`
+- `application/rtf`
 - `application/vnd.android.package-archive`
 - `application/vnd.apache.parquet`
 - `application/vnd.ms-asf`

--- a/src/mimetype/internal/magic.gleam
+++ b/src/mimetype/internal/magic.gleam
@@ -216,6 +216,7 @@ const signatures = [
   Bytes("audio/mp4", [#(4, <<"ftyp":utf8>>), #(8, <<"M4P ":utf8>>)]),
   Bytes("video/quicktime", [#(4, <<"ftyp":utf8>>), #(8, <<"qt  ":utf8>>)]),
   Check("video/mp4", looks_like_iso_bmff_video),
+  Check("application/rtf", looks_like_rtf),
   Check("application/json", looks_like_json),
   Check("text/html", looks_like_html),
   Check("image/svg+xml", looks_like_svg),
@@ -355,6 +356,24 @@ type JsonResult {
   Valid(BitArray, Int)
   Truncated
   Invalid
+}
+
+/// Match RTF documents by their literal `{\rtf<digit>` header.
+///
+/// The Rich Text Format spec requires every RTF document to begin
+/// with `{\rtfN` where `N` is an ASCII digit identifying the RTF
+/// version (`1` is the only widely-deployed value, but the spec
+/// allows any digit). The 6-byte sniff has no false-positive risk
+/// against any other widely-deployed format. Without this rule the
+/// `{\rtf...` prefix slid through to `looks_like_plain_text` because
+/// every byte in the header is printable ASCII, leaving real RTF
+/// uploads silently misdetected as `text/plain`. (#106 / #107)
+fn looks_like_rtf(bytes: BitArray) -> Bool {
+  case bytes {
+    <<0x7B, 0x5C, 0x72, 0x74, 0x66, version, _:bits>> ->
+      version >= 0x30 && version <= 0x39
+    _ -> False
+  }
 }
 
 fn looks_like_json(bytes: BitArray) -> Bool {

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -619,6 +619,44 @@ pub fn detect_pdf_test() {
   should_detect(<<"%PDF-1.7":utf8>>, "application/pdf")
 }
 
+pub fn detect_rtf_minimal_test() {
+  // `{\rtf1` is the minimal valid RTF header — every RTF document
+  // begins with `{\rtfN` where `N` is an ASCII digit.
+  should_detect(<<"{\\rtf1":utf8>>, "application/rtf")
+}
+
+pub fn detect_rtf_with_charset_test() {
+  // Realistic RTF preamble with the `\ansi` charset declaration that
+  // follows the version digit.
+  should_detect(<<"{\\rtf1\\ansi\\deff0":utf8>>, "application/rtf")
+}
+
+pub fn detect_rtf_version_zero_test() {
+  // Spec allows any digit after `\rtf`; verify version `0` works
+  // even though `1` is the only widely-deployed value.
+  should_detect(<<"{\\rtf0":utf8>>, "application/rtf")
+}
+
+pub fn detect_rtf_version_nine_test() {
+  should_detect(<<"{\\rtf9":utf8>>, "application/rtf")
+}
+
+pub fn detect_rtf_must_have_digit_test() {
+  // Not RTF — header is missing the version digit. Falls through to
+  // the plain-text heuristic.
+  mimetype.detect(<<"{\\rtfX":utf8>>)
+  |> mimetype.essence_of
+  |> should.not_equal("application/rtf")
+}
+
+pub fn detect_rtf_partial_prefix_is_not_rtf_test() {
+  // Five bytes is one short of the version digit; the rule requires
+  // at least 6 bytes so we don't accept truncated headers.
+  mimetype.detect(<<"{\\rtf":utf8>>)
+  |> mimetype.essence_of
+  |> should.not_equal("application/rtf")
+}
+
 pub fn detect_zip_test() {
   should_detect(<<0x50, 0x4B, 0x03, 0x04, 20, 0, 0, 0>>, "application/zip")
 }


### PR DESCRIPTION
## Summary

`mimetype.detect_strict(<<\"{\\\\rtf1\":utf8>>)` returned `text/plain`
because every byte in the RTF header is printable ASCII and the
magic-byte detector had no rule for it, so the input slid through to
the `looks_like_plain_text` heuristic. The lookup table already maps
`.rtf` to `application/rtf`, so the asymmetry between extension
lookup and content detection was strictly a bug.

Two real-world consequences this closes:

- Word-import endpoints with an `application/rtf`-only allowlist
  silently rejected valid RTF uploads.
- `text/plain`-permissive endpoints accepted RTF files with embedded
  objects / macros without ever inspecting the actual content type.

## Changes

### `src/mimetype/internal/magic.gleam`

- Add `Check(\"application/rtf\", looks_like_rtf)` to the signatures
  list, placed before the `looks_like_json` / `looks_like_html` /
  `looks_like_xml` checks so RTF is resolved before any text-shaped
  signature gets a chance.
- Implement `looks_like_rtf` to match the literal 5-byte prefix
  `{\\rtf` followed by an ASCII digit (`0x30..0x39`). The 6-byte
  sniff has no false-positive risk against any other widely-deployed
  format.
- Use the `Check` shape rather than `Bytes` because the version byte
  is a digit class, not a literal.

### `test/mimetype_test.gleam`

- New \`detect_rtf_*\` tests covering:
  - Minimal `{\\rtf1` header.
  - Realistic preamble with the `\\ansi` charset.
  - Edge digits `0` and `9` (spec allows any digit).
  - Headers without a digit (`{\\rtfX`) are not RTF.
  - Truncated 5-byte prefix (`{\\rtf`) is not RTF.

### `CHANGELOG.md`

- Fixed entry under `[Unreleased]`.

## Design Decisions

**Why `Check` instead of `Bytes`.** `Bytes(name, [#(offset,
bitarray)])` matches exact bytes; the RTF version is a digit class
(`0`-`9`), so we'd need ten `Bytes` entries to cover it. A single
`Check` is clearer and matches the spec wording.

**Why before JSON / HTML / XML / plain-text checks.** RTF starts with
`{` which the JSON sniffer also looks at; the JSON sniffer would
reject `{\\rtf1` (backslash isn't a valid first character of a JSON
key) but defending against future changes to the JSON sniffer is
free if we run RTF first. Plain-text would also flag a printable
ASCII RTF header — the original bug. Both are sidestepped by
ordering.

**Why `application/rtf` rather than `text/rtf`.** Both are valid
aliases and the issue accepts either. The lookup table normalises
to `application/rtf`, so using the same essence keeps
`extension_to_mime_type(\"rtf\")` and `detect(rtf_bytes)` symmetric.

## Test plan

- [x] `gleam test` — 358 passed (was 352; +6 new tests)
- [x] `just check` — format-check + glinter + check + build + test
- [x] Verified `detect(<<\"{\\\\rtf1\\\\ansi\":utf8>>)` returns
      `application/rtf`
- [x] Verified `detect(<<\"{\\\\rtfX\":utf8>>)` does not return
      `application/rtf`

Closes #106. Closes #107.