### PR TITLE
chore(release): prepare v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-05-09
+
 ### Fixed
 
 - **detect**: RTF documents (`{\rtf1...`) were misdetected as

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "mimetype"
-version = "0.16.0"
+version = "0.17.0"
 description = "MIME type lookup and magic-number detection for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "mimetype" }


### PR DESCRIPTION
### Fixed

- **detect**: RTF documents (`{\rtf1...`) were misdetected as
  `text/plain` because every byte in the header is printable ASCII
  and the magic-byte detector had no rule for them, so the input
  slid through to the `looks_like_plain_text` heuristic. Add a
  6-byte signature check (`{\rtf` + ASCII digit) that resolves to
  `application/rtf`. Closes the security gap where a Word-import
  endpoint with an `application/rtf`-only allowlist would silently
  reject valid RTF uploads, and the inverse case where a
  `text/plain`-permissive endpoint would accept an RTF file with
  embedded objects/macros. (#106, #107)

### Added

- Property-based and metamorphic tests using
  [metamon](https://github.com/nao1215/metamon) covering the public
  surface of the top-level `mimetype` module. Lives in
  `test/mimetype_metamon_test.gleam`. Highlights:
  `parse |> to_string` round-trips up to case (essence is normalised
  to lowercase per RFC 6838); `parse("")` and whitespace-only inputs
  are rejected with `EmptyMimeType`; alpha-only inputs without a
  slash are rejected; `is_image` / `is_text` agree with the
  `image/` / `text/` essence prefixes; `is_a` is reflexive on
  parsed types; extension lookup is case-insensitive and strips a
  leading `.`; `extension_to_mime_type_strict` round-trips through
  `mime_type_to_extensions_strict` for canonical extensions;
  unknown extensions return `application/octet-stream`;
  `detect(<<>>)` returns the octet-stream sentinel and
  `detect_strict(<<>>)` returns `Error(EmptyInput)`; PNG / JPEG /
  PDF / ZIP magic-byte signatures detect correctly; `detect` is
  stable when arbitrary trailing bytes are appended to a known
  signature (a `forall` over `bit_array`).
