### PR TITLE
chore: add FUNDING.yml for GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: nao1215


### PR DESCRIPTION
Add `.github/FUNDING.yml` so the repository displays a Sponsor button linking to nao1215's GitHub Sponsors profile.