### PR TITLE
feat(accept): add mimetype/accept for RFC 9110 content negotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- `mimetype/accept` — RFC 9110 §12.5 content negotiation
+  parser and selector. Handles `Accept`, `Accept-Encoding`,
+  `Accept-Charset`, and `Accept-Language` headers (q-values,
+  wildcards `*/*` and `type/*`, accept-ext parameters,
+  whitespace tolerance per §5.6.3), and implements the §12.5.1
+  proactive-negotiation algorithm via `negotiate/2`. (#116)
+
 ## [0.18.0] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -151,6 +151,45 @@ stops is more useful than discovering it from a surprising result:
 - It does sniff `text/plain` from printable-ASCII-only payloads (the bounded WHATWG-style binary-vs-text heuristic added in #20) and recognises the UTF-8/16/32 BOM signatures, returning `text/plain; charset=<utf-X>` for the BOM cases. This is the **only** text-related sniffing — it does not detect text encodings beyond the BOM marker, and the printable-ASCII fallback emits a bare `text/plain` with no charset parameter.
 - Beyond the four BOM-derived `text/plain; charset=utf-*` signatures it does not parse, validate, or surface MIME-parameter values from the wire.
 
+## Content negotiation
+
+`mimetype/accept` parses RFC 9110 §12.5 `Accept`-family headers and
+picks the best server offer for a given client header.
+
+```gleam
+import mimetype
+import mimetype/accept
+
+pub fn main() {
+  let assert Ok(items) = accept.parse("text/html, application/json;q=0.9")
+  let assert Ok(html) = mimetype.parse("text/html")
+  let assert Ok(json) = mimetype.parse("application/json")
+  accept.negotiate(client_accepts: items, server_offers: [json, html])
+  // -> Some(html)
+}
+```
+
+The same module handles `Accept-Encoding`, `Accept-Charset`, and
+`Accept-Language`:
+
+```gleam
+import mimetype/accept
+
+pub fn main() {
+  let assert Ok(items) =
+    accept.parse_encoding("gzip, br;q=1.0, *;q=0.1")
+  accept.negotiate_value(client_accepts: items, server_offers: ["br", "gzip"])
+  // -> Some("br")
+}
+```
+
+Notes:
+- `q=0` excludes a media range from consideration.
+- A bare `*/*` client header returns the server's first offer
+  (server preference).
+- `Specific(MimeType)` matching is essence-only — RFC §12.5.1
+  parameter-level "more-specific" matching is currently out of scope.
+
 ## Reader-based detection
 
 `detect_reader` and `detect_reader_strict` let callers detect a MIME

--- a/src/mimetype/accept.gleam
+++ b/src/mimetype/accept.gleam
@@ -1,0 +1,522 @@
+//// RFC 9110 §12.5 content negotiation: parser and selector for the
+//// `Accept`, `Accept-Encoding`, `Accept-Charset`, and `Accept-Language`
+//// header families.
+////
+//// The module exposes:
+////   - `parse/1` — turn a raw `Accept` header into a list of
+////     `AcceptItem` values, preserving the client's q-values and any
+////     accept-ext parameters (RFC 9110 §12.5.1).
+////   - `prefer/1` — stable-sort parsed items by `(q desc, specificity
+////     desc, accept-ext count desc)` so callers can iterate in the
+////     order the client most prefers.
+////   - `negotiate/2` — given a parsed client header and a list of
+////     server offers, return the best `MimeType` to serve, or `None`
+////     when no offer is acceptable. Implements the §12.5.1
+////     proactive-negotiation algorithm with the documented essence-only
+////     matching restriction.
+////   - `parse_encoding/1`, `parse_charset/1`, `parse_language/1` and
+////     their companion `prefer_values/1` / `negotiate_value/2`.
+
+import gleam/bool
+import gleam/float
+import gleam/int
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/order.{type Order, Eq}
+import gleam/string
+import mimetype.{type MimeType}
+import mimetype/internal/accept as accept_internal
+import mimetype/internal/parse as parse_internal
+
+/// A single media-range entry as it appears on the wire.
+///
+/// - `Specific(mt)` matches a concrete `type/subtype`. Parameter-level
+///   "more-specific" matching per RFC 9110 §12.5.1 is out of scope:
+///   matching looks at the essence only and ignores attached
+///   media-range parameters (other than `q` and accept-ext, which are
+///   carried on `AcceptItem`).
+/// - `TypeWildcard(type_)` matches any subtype within a top-level type
+///   (e.g. `image/*`). The carried `type_` is already lowercased.
+/// - `AnyType` matches any media range (`*/*`).
+pub type MediaRange {
+  Specific(MimeType)
+  TypeWildcard(type_: String)
+  AnyType
+}
+
+/// One parsed entry from an `Accept` header. `q` defaults to `1.0` if
+/// the wire form omits it; `extensions` holds the accept-ext name/value
+/// pairs that appeared *after* the `q=` parameter, with names
+/// lowercased and values preserved.
+pub type AcceptItem {
+  AcceptItem(range: MediaRange, q: Float, extensions: List(#(String, String)))
+}
+
+/// One parsed entry from `Accept-Encoding`, `Accept-Charset`, or
+/// `Accept-Language`. The `value` is lowercased.
+pub type ValueItem {
+  ValueItem(value: String, q: Float)
+}
+
+/// Why a header could not be parsed.
+pub type AcceptError {
+  /// An entry did not match the expected `media-range[;params]` shape.
+  /// `at` is the zero-based entry index; `raw` is the raw entry text.
+  Malformed(at: Int, raw: String)
+  /// An entry's q-value was syntactically invalid.
+  InvalidQValue(raw: String)
+  /// A media-range field was not a wildcard, a `type/*` form, or a
+  /// valid `type/subtype` per RFC 6838.
+  InvalidMediaRange(raw: String)
+}
+
+// ---------------------------------------------------------------------------
+// Accept header
+// ---------------------------------------------------------------------------
+
+/// Parse an `Accept` header into a list of `AcceptItem` values in the
+/// order they appeared on the wire. Use `prefer/1` afterwards to sort
+/// by preference.
+///
+/// Whitespace tolerance: empty entries (`"a, , b"`) and surrounding
+/// whitespace on each entry / parameter are accepted per RFC 9110
+/// §5.6.3.
+pub fn parse(header: String) -> Result(List(AcceptItem), AcceptError) {
+  let trimmed = string.trim(header)
+  use <- bool.guard(when: trimmed == "", return: Ok([]))
+  accept_internal.split_on_unquoted_commas(trimmed)
+  |> list.index_map(fn(entry, i) { #(i, entry) })
+  |> list.filter(fn(pair) {
+    let #(_, raw) = pair
+    string.trim(raw) != ""
+  })
+  |> list.try_map(fn(pair) {
+    let #(i, raw) = pair
+    parse_entry(i, raw)
+  })
+}
+
+fn parse_entry(index: Int, raw: String) -> Result(AcceptItem, AcceptError) {
+  let trimmed = string.trim(raw)
+  let segments = parse_internal.split_on_unquoted_semicolons(trimmed)
+  case segments {
+    [] -> Error(Malformed(at: index, raw: raw))
+    [range_raw, ..params] -> parse_entry_parts(index, raw, range_raw, params)
+  }
+}
+
+fn parse_entry_parts(
+  index: Int,
+  raw: String,
+  range_raw: String,
+  params: List(String),
+) -> Result(AcceptItem, AcceptError) {
+  let range_trimmed = string.trim(range_raw)
+  case accept_internal.split_at_q(params) {
+    Error(Nil) -> Error(InvalidQValue(raw: raw))
+    Ok(#(before_q, q, after_q)) ->
+      case parse_media_range(range_trimmed, before_q) {
+        Error(_) -> Error(InvalidMediaRange(raw: range_trimmed))
+        Ok(range) -> finish_entry(index, raw, range, q, after_q)
+      }
+  }
+}
+
+fn finish_entry(
+  index: Int,
+  raw: String,
+  range: MediaRange,
+  q: Float,
+  after_q: List(String),
+) -> Result(AcceptItem, AcceptError) {
+  case parse_extensions(after_q) {
+    Error(Nil) -> Error(Malformed(at: index, raw: raw))
+    Ok(extensions) -> Ok(AcceptItem(range: range, q: q, extensions: extensions))
+  }
+}
+
+fn parse_media_range(
+  range_raw: String,
+  media_params: List(String),
+) -> Result(MediaRange, Nil) {
+  let lower = string.lowercase(range_raw)
+  case lower, media_params {
+    "*/*", [] -> Ok(AnyType)
+    "*/*", _ -> Ok(AnyType)
+    _, _ ->
+      case string.split_once(lower, on: "/") {
+        Error(Nil) -> Error(Nil)
+        Ok(#(_t, "*")) ->
+          case string.split_once(lower, on: "/") {
+            Ok(#(t, _)) ->
+              case t, is_valid_token(t) {
+                "*", _ -> Error(Nil)
+                _, True -> Ok(TypeWildcard(type_: t))
+                _, False -> Error(Nil)
+              }
+            Error(Nil) -> Error(Nil)
+          }
+        Ok(#("*", _)) -> Error(Nil)
+        Ok(_) -> {
+          let wire = case media_params {
+            [] -> range_raw
+            _ ->
+              range_raw
+              <> "; "
+              <> string.join(list.map(media_params, string.trim), "; ")
+          }
+          case mimetype.parse(wire) {
+            Ok(mt) -> Ok(Specific(mt))
+            Error(_) -> Error(Nil)
+          }
+        }
+      }
+  }
+}
+
+fn is_valid_token(s: String) -> Bool {
+  parse_internal.is_token(s)
+}
+
+fn parse_extensions(
+  segments: List(String),
+) -> Result(List(#(String, String)), Nil) {
+  segments
+  |> list.try_fold([], fn(acc, seg) {
+    let trimmed = string.trim(seg)
+    case trimmed {
+      "" -> Ok(acc)
+      _ ->
+        case string.split_once(trimmed, on: "=") {
+          Error(Nil) -> {
+            // accept-ext can be a bare token without a value
+            // (RFC 9110 §12.5.1: `parameter = token "=" ( token / quoted-string )`,
+            // but in practice some servers emit bare tokens).
+            // We model the bare form as `name = ""`.
+            let name = trimmed |> string.lowercase
+            Ok([#(name, ""), ..acc])
+          }
+          Ok(#(name, value)) -> {
+            let normalized_name = name |> string.trim |> string.lowercase
+            let normalized_value = value |> string.trim |> strip_quotes
+            Ok([#(normalized_name, normalized_value), ..acc])
+          }
+        }
+    }
+  })
+  |> result_map_reverse
+}
+
+fn result_map_reverse(r: Result(List(a), e)) -> Result(List(a), e) {
+  case r {
+    Ok(xs) -> Ok(list.reverse(xs))
+    Error(e) -> Error(e)
+  }
+}
+
+fn strip_quotes(value: String) -> String {
+  let is_quoted =
+    string.starts_with(value, "\"") && string.ends_with(value, "\"")
+  use <- bool.guard(when: !is_quoted, return: value)
+  use <- bool.guard(when: string.length(value) < 2, return: value)
+  value |> string.drop_start(1) |> string.drop_end(1)
+}
+
+/// Stable-sort parsed `AcceptItem`s by client preference:
+///   1. q-value descending,
+///   2. specificity descending (concrete > `type/*` > `*/*`),
+///   3. accept-ext count descending (RFC 9110 §12.5.1 tie-breaker).
+pub fn prefer(items: List(AcceptItem)) -> List(AcceptItem) {
+  list.sort(items, compare_accept_items)
+}
+
+fn compare_accept_items(a: AcceptItem, b: AcceptItem) -> Order {
+  // q desc
+  let q_order = float.compare(b.q, a.q)
+  use <- chain(q_order)
+  // specificity desc
+  let s_order = int.compare(specificity(b.range), specificity(a.range))
+  use <- chain(s_order)
+  // ext count desc
+  int.compare(list.length(b.extensions), list.length(a.extensions))
+}
+
+fn chain(primary: Order, fallback: fn() -> Order) -> Order {
+  case primary {
+    Eq -> fallback()
+    other -> other
+  }
+}
+
+fn specificity(range: MediaRange) -> Int {
+  case range {
+    Specific(_) -> 3
+    TypeWildcard(_) -> 2
+    AnyType -> 1
+  }
+}
+
+/// Pick the best server offer for a parsed `Accept` header. Returns
+/// `None` when no offer is acceptable (e.g. every match has `q=0`, or
+/// `server_offers` is empty).
+///
+/// Special case: if every client item is `AnyType` with `q>0`, the
+/// server's first offer wins (server preference). Otherwise we score
+/// each server offer by the best matching client item — `(q,
+/// specificity, ext_count)` — and break ties by the order the offer
+/// appears in `server_offers`.
+///
+/// Matching is essence-only: parameter-level "more-specific" matching
+/// per RFC 9110 §12.5.1 is out of scope.
+pub fn negotiate(
+  client_accepts client: List(AcceptItem),
+  server_offers offers: List(MimeType),
+) -> Option(MimeType) {
+  case offers {
+    [] -> None
+    _ ->
+      case client {
+        [] -> first(offers)
+        _ ->
+          case all_any_type(client) {
+            True -> first(offers)
+            False -> best_server_match(client, offers)
+          }
+      }
+  }
+}
+
+fn first(offers: List(MimeType)) -> Option(MimeType) {
+  case offers {
+    [head, ..] -> Some(head)
+    [] -> None
+  }
+}
+
+fn all_any_type(items: List(AcceptItem)) -> Bool {
+  list.all(items, fn(item) {
+    case item.range, item.q >. 0.0 {
+      AnyType, True -> True
+      _, _ -> False
+    }
+  })
+}
+
+fn best_server_match(
+  client: List(AcceptItem),
+  offers: List(MimeType),
+) -> Option(MimeType) {
+  offers
+  |> list.index_map(fn(offer, i) { #(i, offer, best_match_for(offer, client)) })
+  |> list.filter_map(fn(triple) {
+    let #(i, offer, m) = triple
+    case m {
+      Some(score) -> Ok(#(i, offer, score))
+      None -> Error(Nil)
+    }
+  })
+  |> list.sort(compare_offer_scores)
+  |> list.first
+  |> option.from_result
+  |> option.map(fn(t) {
+    let #(_, offer, _) = t
+    offer
+  })
+}
+
+type MatchScore {
+  MatchScore(q: Float, specificity: Int, ext_count: Int)
+}
+
+fn compare_offer_scores(
+  a: #(Int, MimeType, MatchScore),
+  b: #(Int, MimeType, MatchScore),
+) -> Order {
+  let #(i_a, _, score_a) = a
+  let #(i_b, _, score_b) = b
+  let q_order = float.compare(score_b.q, score_a.q)
+  use <- chain(q_order)
+  let s_order = int.compare(score_b.specificity, score_a.specificity)
+  use <- chain(s_order)
+  let e_order = int.compare(score_b.ext_count, score_a.ext_count)
+  use <- chain(e_order)
+  // server preference: lower index wins
+  int.compare(i_a, i_b)
+}
+
+fn best_match_for(
+  offer: MimeType,
+  client: List(AcceptItem),
+) -> Option(MatchScore) {
+  let offer_essence = mimetype.essence_of(offer)
+  client
+  |> list.filter_map(fn(item) {
+    case range_matches(item.range, offer_essence) {
+      True ->
+        case item.q >. 0.0 {
+          True ->
+            Ok(MatchScore(
+              q: item.q,
+              specificity: specificity(item.range),
+              ext_count: list.length(item.extensions),
+            ))
+          False -> Error(Nil)
+        }
+      False -> Error(Nil)
+    }
+  })
+  |> max_score
+}
+
+fn max_score(scores: List(MatchScore)) -> Option(MatchScore) {
+  case scores {
+    [] -> None
+    [head, ..rest] ->
+      Some(
+        list.fold(rest, head, fn(best, candidate) {
+          case better_score(candidate, best) {
+            True -> candidate
+            False -> best
+          }
+        }),
+      )
+  }
+}
+
+fn better_score(a: MatchScore, b: MatchScore) -> Bool {
+  case float.compare(a.q, b.q) {
+    order.Gt -> True
+    order.Lt -> False
+    Eq ->
+      case int.compare(a.specificity, b.specificity) {
+        order.Gt -> True
+        order.Lt -> False
+        Eq ->
+          case int.compare(a.ext_count, b.ext_count) {
+            order.Gt -> True
+            _ -> False
+          }
+      }
+  }
+}
+
+fn range_matches(range: MediaRange, offer_essence: String) -> Bool {
+  case range {
+    AnyType -> True
+    TypeWildcard(type_:) ->
+      case string.split_once(offer_essence, on: "/") {
+        Ok(#(t, _)) -> t == type_
+        Error(Nil) -> False
+      }
+    Specific(mt) -> mimetype.essence_of(mt) == offer_essence
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Encoding / Charset / Language
+// ---------------------------------------------------------------------------
+
+/// Parse an `Accept-Encoding` header.
+pub fn parse_encoding(header: String) -> Result(List(ValueItem), AcceptError) {
+  parse_value_header(header)
+}
+
+/// Parse an `Accept-Charset` header.
+pub fn parse_charset(header: String) -> Result(List(ValueItem), AcceptError) {
+  parse_value_header(header)
+}
+
+/// Parse an `Accept-Language` header.
+pub fn parse_language(header: String) -> Result(List(ValueItem), AcceptError) {
+  parse_value_header(header)
+}
+
+fn parse_value_header(header: String) -> Result(List(ValueItem), AcceptError) {
+  case accept_internal.parse_token_list(header) {
+    Error(Nil) -> Error(InvalidQValue(raw: header))
+    Ok(pairs) ->
+      Ok(
+        list.map(pairs, fn(p) {
+          let #(value, q) = p
+          ValueItem(value: value, q: q)
+        }),
+      )
+  }
+}
+
+/// Stable-sort `ValueItem`s by q-value descending.
+pub fn prefer_values(items: List(ValueItem)) -> List(ValueItem) {
+  list.sort(items, fn(a, b) { float.compare(b.q, a.q) })
+}
+
+/// Pick the best server offer for an `Accept-Encoding` /
+/// `Accept-Charset` / `Accept-Language` header. The `*` wildcard
+/// matches any value not already named explicitly; entries with `q=0`
+/// are excluded.
+pub fn negotiate_value(
+  client_accepts client: List(ValueItem),
+  server_offers offers: List(String),
+) -> Option(String) {
+  case offers {
+    [] -> None
+    _ ->
+      case client {
+        [] ->
+          case offers {
+            [head, ..] -> Some(head)
+            [] -> None
+          }
+        _ -> best_value_match(client, offers)
+      }
+  }
+}
+
+fn best_value_match(
+  client: List(ValueItem),
+  offers: List(String),
+) -> Option(String) {
+  let normalised_offers =
+    list.index_map(offers, fn(offer, i) { #(i, offer, string.lowercase(offer)) })
+  let wildcard_q = find_q(client, "*")
+  normalised_offers
+  |> list.filter_map(fn(triple) {
+    let #(i, original, lower) = triple
+    let explicit_q = find_q(client, lower)
+    let chosen = case explicit_q, wildcard_q {
+      Some(q), _ -> Some(q)
+      None, Some(q) -> Some(q)
+      None, None -> None
+    }
+    case chosen {
+      Some(q) ->
+        case q >. 0.0 {
+          True -> Ok(#(i, original, q))
+          False -> Error(Nil)
+        }
+      None -> Error(Nil)
+    }
+  })
+  |> list.sort(fn(a, b) {
+    let #(i_a, _, q_a) = a
+    let #(i_b, _, q_b) = b
+    let q_order = float.compare(q_b, q_a)
+    use <- chain(q_order)
+    int.compare(i_a, i_b)
+  })
+  |> list.first
+  |> option.from_result
+  |> option.map(fn(t) {
+    let #(_, original, _) = t
+    original
+  })
+}
+
+fn find_q(items: List(ValueItem), value: String) -> Option(Float) {
+  list.find_map(items, fn(item) {
+    case item.value == value {
+      True -> Ok(item.q)
+      False -> Error(Nil)
+    }
+  })
+  |> option.from_result
+}

--- a/src/mimetype/internal/accept.gleam
+++ b/src/mimetype/internal/accept.gleam
@@ -1,0 +1,184 @@
+//// Internal parser primitives for RFC 9110 §12.5 `Accept`-family
+//// headers. Kept private (in `mimetype/internal/`) — the facade
+//// `mimetype/accept` re-exports the parts callers need.
+////
+//// Responsibilities:
+////   - Quote-aware splitting on top-level commas.
+////   - q-value parsing per RFC 9110 §12.5.5
+////     (`qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )`).
+////   - Splitting a parameter list at the first `q=` parameter so the
+////     facade can separate media-range parameters from accept-ext.
+////   - Token-list parsing for `Accept-Encoding`, `Accept-Charset`, and
+////     `Accept-Language` (semicolon-separated `value[;q=...]`).
+
+import gleam/bool
+import gleam/int
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/string
+
+/// Split a header value on top-level `,` characters while keeping
+/// commas that appear inside a quoted-string attached to the
+/// surrounding entry. Backslash escapes inside a quoted-string are
+/// honoured.
+pub fn split_on_unquoted_commas(s: String) -> List(String) {
+  do_split_commas(s, "", [], False, False)
+  |> list.reverse
+}
+
+fn do_split_commas(
+  remaining: String,
+  current: String,
+  acc: List(String),
+  in_quote: Bool,
+  escape: Bool,
+) -> List(String) {
+  case string.pop_grapheme(remaining) {
+    Error(Nil) -> [current, ..acc]
+    Ok(#(g, rest)) ->
+      case escape, g, in_quote {
+        True, _, _ -> do_split_commas(rest, current <> g, acc, in_quote, False)
+        False, "\\", True ->
+          do_split_commas(rest, current <> g, acc, in_quote, True)
+        False, "\"", _ ->
+          do_split_commas(rest, current <> g, acc, !in_quote, False)
+        False, ",", False ->
+          do_split_commas(rest, "", [current, ..acc], False, False)
+        False, _, _ -> do_split_commas(rest, current <> g, acc, in_quote, False)
+      }
+  }
+}
+
+/// Walk a parameter segment list (already split on `;`) and return
+/// `#(params_before_q, q_value, params_after_q)`. The `q` lookup is
+/// case-insensitive on the name. Returns `Error(Nil)` if a `q=`
+/// segment is present but the value is not a valid qvalue. Returns
+/// `Ok(#(all, 1.0, []))` if no `q=` parameter is present.
+pub fn split_at_q(
+  segments: List(String),
+) -> Result(#(List(String), Float, List(String)), Nil) {
+  do_split_at_q(segments, [])
+}
+
+fn do_split_at_q(
+  remaining: List(String),
+  before: List(String),
+) -> Result(#(List(String), Float, List(String)), Nil) {
+  case remaining {
+    [] -> Ok(#(list.reverse(before), 1.0, []))
+    [seg, ..rest] ->
+      case extract_q(seg) {
+        Some(raw) ->
+          case parse_q_value(raw) {
+            Ok(q) -> Ok(#(list.reverse(before), q, rest))
+            Error(Nil) -> Error(Nil)
+          }
+        None -> do_split_at_q(rest, [seg, ..before])
+      }
+  }
+}
+
+fn extract_q(segment: String) -> Option(String) {
+  case string.split_once(segment, on: "=") {
+    Error(Nil) -> None
+    Ok(#(name, value)) -> {
+      let normalized = name |> string.trim |> string.lowercase
+      case normalized == "q" {
+        True -> Some(string.trim(value))
+        False -> None
+      }
+    }
+  }
+}
+
+/// Parse an RFC 9110 §12.5.5 qvalue (`0`, `0.5`, `1`, `1.000` etc.).
+///
+/// Accepts the lenient short forms `0`, `0.`, `1`, `1.` and the
+/// unquoted form (RFC 9110 disallows surrounding double quotes for
+/// the `weight` rule). Returns `Error(Nil)` for empty input, values
+/// outside `[0.0, 1.0]`, more than three fractional digits, or any
+/// non-digit character.
+pub fn parse_q_value(raw: String) -> Result(Float, Nil) {
+  let trimmed = string.trim(raw)
+  use <- bool.guard(when: trimmed == "", return: Error(Nil))
+  case string.split_once(trimmed, on: ".") {
+    Error(Nil) ->
+      case trimmed {
+        "0" -> Ok(0.0)
+        "1" -> Ok(1.0)
+        _ -> Error(Nil)
+      }
+    Ok(#(int_part, frac_part)) ->
+      case int_part {
+        "0" -> parse_fraction_with_int(0, frac_part)
+        "1" -> parse_fraction_with_int(1, frac_part)
+        _ -> Error(Nil)
+      }
+  }
+}
+
+fn parse_fraction_with_int(
+  int_part: Int,
+  frac_part: String,
+) -> Result(Float, Nil) {
+  // RFC 9110: up to 3 fractional digits.
+  use <- bool.guard(when: string.length(frac_part) > 3, return: Error(Nil))
+  case frac_part {
+    "" -> Ok(int.to_float(int_part))
+    _ ->
+      case int.parse(frac_part) {
+        Error(Nil) -> Error(Nil)
+        Ok(frac_int) -> {
+          // For "1", every fractional digit must be 0 to keep the
+          // total <= 1.0.
+          use <- bool.guard(
+            when: int_part == 1 && frac_int != 0,
+            return: Error(Nil),
+          )
+          let denom = case string.length(frac_part) {
+            1 -> 10.0
+            2 -> 100.0
+            3 -> 1000.0
+            // length 0 handled above
+            _ -> 1.0
+          }
+          Ok(int.to_float(int_part) +. int.to_float(frac_int) /. denom)
+        }
+      }
+  }
+}
+
+/// Parse the simple comma-separated `value[;q=...]` form used by
+/// `Accept-Encoding`, `Accept-Charset`, and `Accept-Language`. Returns
+/// `Error(Nil)` if any entry has a syntactically invalid q-value or a
+/// missing value.
+pub fn parse_token_list(header: String) -> Result(List(#(String, Float)), Nil) {
+  let trimmed = string.trim(header)
+  use <- bool.guard(when: trimmed == "", return: Ok([]))
+  split_on_unquoted_commas(trimmed)
+  |> list.filter_map(fn(entry) {
+    case string.trim(entry) {
+      "" -> Error(Nil)
+      non_empty -> Ok(non_empty)
+    }
+  })
+  |> list.try_map(parse_token_entry)
+}
+
+fn parse_token_entry(entry: String) -> Result(#(String, Float), Nil) {
+  let segments = case string.contains(entry, ";") {
+    True -> string.split(entry, on: ";")
+    False -> [entry]
+  }
+  case segments {
+    [] -> Error(Nil)
+    [value_raw, ..params] -> {
+      let value = value_raw |> string.trim |> string.lowercase
+      use <- bool.guard(when: value == "", return: Error(Nil))
+      case split_at_q(params) {
+        Error(Nil) -> Error(Nil)
+        Ok(#(_before, q, _after)) -> Ok(#(value, q))
+      }
+    }
+  }
+}

--- a/src/mimetype/internal/parse.gleam
+++ b/src/mimetype/internal/parse.gleam
@@ -107,7 +107,7 @@ pub fn is_token(s: String) -> Bool {
 /// surrounding value. Backslash escapes (`\"`, `\\`, `\;` etc.) within
 /// a quoted-string are honoured so the next character does not toggle
 /// the quote state.
-fn split_on_unquoted_semicolons(s: String) -> List(String) {
+pub fn split_on_unquoted_semicolons(s: String) -> List(String) {
   do_split_semis(s, "", [], False, False)
   |> list.reverse
 }

--- a/test/mimetype_accept_test.gleam
+++ b/test/mimetype_accept_test.gleam
@@ -1,0 +1,475 @@
+import gleam/list
+import gleam/option.{None, Some}
+import gleeunit
+import gleeunit/should
+import mimetype
+import mimetype/accept
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+fn mt(s: String) -> mimetype.MimeType {
+  let assert Ok(value) = mimetype.parse(s)
+  value
+}
+
+fn ranges(items: List(accept.AcceptItem)) -> List(accept.MediaRange) {
+  list.map(items, fn(i) { i.range })
+}
+
+fn essences(items: List(accept.AcceptItem)) -> List(String) {
+  list.map(items, fn(item) {
+    case item.range {
+      accept.Specific(m) -> mimetype.essence_of(m)
+      accept.TypeWildcard(t) -> t <> "/*"
+      accept.AnyType -> "*/*"
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// 1. parse basics
+// ---------------------------------------------------------------------------
+
+pub fn parse_empty_string_test() {
+  accept.parse("")
+  |> should.equal(Ok([]))
+}
+
+pub fn parse_whitespace_only_test() {
+  accept.parse("   ")
+  |> should.equal(Ok([]))
+}
+
+pub fn parse_single_concrete_test() {
+  let assert Ok(items) = accept.parse("text/html")
+  items
+  |> ranges
+  |> should.equal([accept.Specific(mt("text/html"))])
+}
+
+pub fn parse_default_q_is_1_test() {
+  let assert Ok(items) = accept.parse("text/html")
+  case items {
+    [head] -> head.q |> should.equal(1.0)
+    _ -> should.fail()
+  }
+}
+
+pub fn parse_star_star_test() {
+  let assert Ok(items) = accept.parse("*/*")
+  items
+  |> ranges
+  |> should.equal([accept.AnyType])
+}
+
+pub fn parse_type_wildcard_test() {
+  let assert Ok(items) = accept.parse("image/*")
+  items
+  |> ranges
+  |> should.equal([accept.TypeWildcard("image")])
+}
+
+pub fn parse_multiple_entries_test() {
+  let assert Ok(items) = accept.parse("text/html, application/json, image/*")
+  items
+  |> essences
+  |> should.equal(["text/html", "application/json", "image/*"])
+}
+
+pub fn parse_preserves_wire_order_test() {
+  let assert Ok(items) = accept.parse("application/json, text/html")
+  items
+  |> essences
+  |> should.equal(["application/json", "text/html"])
+}
+
+pub fn parse_q_value_extracted_test() {
+  let assert Ok(items) = accept.parse("text/html;q=0.5")
+  case items {
+    [head] -> {
+      head.q |> should.equal(0.5)
+      head.range |> should.equal(accept.Specific(mt("text/html")))
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn parse_media_params_kept_test() {
+  let assert Ok(items) = accept.parse("text/html;level=1;q=0.4")
+  case items {
+    [head] -> {
+      head.q |> should.equal(0.4)
+      case head.range {
+        accept.Specific(m) ->
+          mimetype.parameter_of(m, "level") |> should.equal(Some("1"))
+        _ -> should.fail()
+      }
+    }
+    _ -> should.fail()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. parse q-value edge cases
+// ---------------------------------------------------------------------------
+
+pub fn q_value_short_zero_test() {
+  let assert Ok(items) = accept.parse("text/html;q=0")
+  case items {
+    [head] -> head.q |> should.equal(0.0)
+    _ -> should.fail()
+  }
+}
+
+pub fn q_value_short_one_test() {
+  let assert Ok(items) = accept.parse("text/html;q=1")
+  case items {
+    [head] -> head.q |> should.equal(1.0)
+    _ -> should.fail()
+  }
+}
+
+pub fn q_value_zero_dot_test() {
+  let assert Ok(items) = accept.parse("text/html;q=0.")
+  case items {
+    [head] -> head.q |> should.equal(0.0)
+    _ -> should.fail()
+  }
+}
+
+pub fn q_value_one_point_zero_zero_zero_test() {
+  let assert Ok(items) = accept.parse("text/html;q=1.000")
+  case items {
+    [head] -> head.q |> should.equal(1.0)
+    _ -> should.fail()
+  }
+}
+
+pub fn q_value_three_decimals_test() {
+  let assert Ok(items) = accept.parse("text/html;q=0.125")
+  case items {
+    [head] -> head.q |> should.equal(0.125)
+    _ -> should.fail()
+  }
+}
+
+pub fn q_value_uppercase_name_test() {
+  let assert Ok(items) = accept.parse("text/html;Q=0.5")
+  case items {
+    [head] -> head.q |> should.equal(0.5)
+    _ -> should.fail()
+  }
+}
+
+pub fn q_value_invalid_two_test() {
+  case accept.parse("text/html;q=2") {
+    Error(accept.InvalidQValue(_)) -> Nil
+    other -> should.fail() |> fn(_) { other |> should.equal(Ok([])) }
+  }
+}
+
+pub fn q_value_invalid_negative_test() {
+  case accept.parse("text/html;q=-0.5") {
+    Error(accept.InvalidQValue(_)) -> Nil
+    other -> should.fail() |> fn(_) { other |> should.equal(Ok([])) }
+  }
+}
+
+pub fn q_value_invalid_four_decimals_test() {
+  case accept.parse("text/html;q=0.1234") {
+    Error(accept.InvalidQValue(_)) -> Nil
+    other -> should.fail() |> fn(_) { other |> should.equal(Ok([])) }
+  }
+}
+
+pub fn q_value_invalid_one_with_nonzero_test() {
+  case accept.parse("text/html;q=1.5") {
+    Error(accept.InvalidQValue(_)) -> Nil
+    other -> should.fail() |> fn(_) { other |> should.equal(Ok([])) }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. parse quoted parameter values
+// ---------------------------------------------------------------------------
+
+pub fn parse_quoted_value_with_comma_test() {
+  let assert Ok(items) = accept.parse("text/plain;description=\"a, b\";q=0.5")
+  case items {
+    [head] -> {
+      head.q |> should.equal(0.5)
+      case head.range {
+        accept.Specific(m) ->
+          mimetype.parameter_of(m, "description")
+          |> should.equal(Some("a, b"))
+        _ -> should.fail()
+      }
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn parse_quoted_value_with_semicolon_test() {
+  let assert Ok(items) = accept.parse("text/plain;tag=\"x;y\"")
+  case items {
+    [head] ->
+      case head.range {
+        accept.Specific(m) ->
+          mimetype.parameter_of(m, "tag") |> should.equal(Some("x;y"))
+        _ -> should.fail()
+      }
+    _ -> should.fail()
+  }
+}
+
+pub fn parse_two_entries_quoted_value_test() {
+  let assert Ok(items) = accept.parse("text/plain;t=\"a,b\", application/json")
+  items
+  |> essences
+  |> should.equal(["text/plain", "application/json"])
+}
+
+// ---------------------------------------------------------------------------
+// 4. parse whitespace tolerance
+// ---------------------------------------------------------------------------
+
+pub fn whitespace_around_entries_test() {
+  let assert Ok(items) = accept.parse("  text/html  ,  application/json  ")
+  items
+  |> essences
+  |> should.equal(["text/html", "application/json"])
+}
+
+pub fn empty_entries_skipped_test() {
+  let assert Ok(items) = accept.parse("text/html, , application/json")
+  items
+  |> essences
+  |> should.equal(["text/html", "application/json"])
+}
+
+pub fn whitespace_around_q_test() {
+  let assert Ok(items) = accept.parse("text/html ;  q  =  0.5")
+  case items {
+    [head] -> head.q |> should.equal(0.5)
+    _ -> should.fail()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. parse malformed
+// ---------------------------------------------------------------------------
+
+pub fn malformed_no_slash_test() {
+  case accept.parse("garbage") {
+    Error(accept.InvalidMediaRange(_)) -> Nil
+    other -> other |> should.equal(Ok([]))
+  }
+}
+
+pub fn malformed_subtype_wildcard_with_type_wildcard_test() {
+  case accept.parse("*/text") {
+    Error(accept.InvalidMediaRange(_)) -> Nil
+    other -> other |> should.equal(Ok([]))
+  }
+}
+
+pub fn malformed_empty_essence_test() {
+  case accept.parse("/") {
+    Error(accept.InvalidMediaRange(_)) -> Nil
+    other -> other |> should.equal(Ok([]))
+  }
+}
+
+pub fn malformed_only_comma_test() {
+  let assert Ok(items) = accept.parse(",,,")
+  items |> should.equal([])
+}
+
+// ---------------------------------------------------------------------------
+// 6. prefer sorting
+// ---------------------------------------------------------------------------
+
+pub fn prefer_q_descending_test() {
+  let assert Ok(items) = accept.parse("text/html;q=0.5, application/json;q=0.9")
+  accept.prefer(items)
+  |> essences
+  |> should.equal(["application/json", "text/html"])
+}
+
+pub fn prefer_specificity_breaks_tie_test() {
+  let assert Ok(items) = accept.parse("*/*, text/*, text/html")
+  accept.prefer(items)
+  |> essences
+  |> should.equal(["text/html", "text/*", "*/*"])
+}
+
+pub fn prefer_is_stable_test() {
+  let assert Ok(items) = accept.parse("text/html, application/json")
+  accept.prefer(items)
+  |> essences
+  |> should.equal(["text/html", "application/json"])
+}
+
+pub fn prefer_ext_count_breaks_tie_test() {
+  let assert Ok(items) = accept.parse("text/html;q=0.5, text/plain;q=0.5;a=1")
+  accept.prefer(items)
+  |> essences
+  |> should.equal(["text/plain", "text/html"])
+}
+
+// ---------------------------------------------------------------------------
+// 7. negotiate
+// ---------------------------------------------------------------------------
+
+pub fn negotiate_empty_offers_test() {
+  let assert Ok(items) = accept.parse("text/html")
+  accept.negotiate(client_accepts: items, server_offers: [])
+  |> should.equal(None)
+}
+
+pub fn negotiate_empty_client_returns_first_test() {
+  accept.negotiate(client_accepts: [], server_offers: [
+    mt("text/html"),
+    mt("application/json"),
+  ])
+  |> should.equal(Some(mt("text/html")))
+}
+
+pub fn negotiate_star_star_returns_server_first_test() {
+  let assert Ok(items) = accept.parse("*/*")
+  accept.negotiate(client_accepts: items, server_offers: [
+    mt("application/json"),
+    mt("text/html"),
+  ])
+  |> should.equal(Some(mt("application/json")))
+}
+
+pub fn negotiate_exact_match_test() {
+  let assert Ok(items) = accept.parse("text/html, application/json;q=0.5")
+  accept.negotiate(client_accepts: items, server_offers: [
+    mt("application/json"),
+    mt("text/html"),
+  ])
+  |> should.equal(Some(mt("text/html")))
+}
+
+pub fn negotiate_type_wildcard_match_test() {
+  let assert Ok(items) = accept.parse("image/*")
+  accept.negotiate(client_accepts: items, server_offers: [
+    mt("application/json"),
+    mt("image/png"),
+  ])
+  |> should.equal(Some(mt("image/png")))
+}
+
+pub fn negotiate_q_zero_excludes_test() {
+  let assert Ok(items) = accept.parse("text/html;q=0, application/json")
+  accept.negotiate(client_accepts: items, server_offers: [
+    mt("text/html"),
+    mt("application/json"),
+  ])
+  |> should.equal(Some(mt("application/json")))
+}
+
+pub fn negotiate_no_match_test() {
+  let assert Ok(items) = accept.parse("image/png")
+  accept.negotiate(client_accepts: items, server_offers: [
+    mt("text/html"),
+    mt("application/json"),
+  ])
+  |> should.equal(None)
+}
+
+pub fn negotiate_specificity_wins_test() {
+  let assert Ok(items) = accept.parse("*/*;q=0.5, text/html;q=0.5")
+  accept.negotiate(client_accepts: items, server_offers: [
+    mt("application/json"),
+    mt("text/html"),
+  ])
+  |> should.equal(Some(mt("text/html")))
+}
+
+// ---------------------------------------------------------------------------
+// 8. encoding / charset / language
+// ---------------------------------------------------------------------------
+
+pub fn parse_encoding_basic_test() {
+  let assert Ok(items) = accept.parse_encoding("gzip, br;q=1.0, *;q=0.1")
+  list.length(items) |> should.equal(3)
+}
+
+pub fn parse_encoding_lowercases_test() {
+  let assert Ok(items) = accept.parse_encoding("GZIP")
+  case items {
+    [head] -> head.value |> should.equal("gzip")
+    _ -> should.fail()
+  }
+}
+
+pub fn negotiate_encoding_picks_highest_q_test() {
+  let assert Ok(items) = accept.parse_encoding("gzip;q=0.5, br;q=1.0")
+  accept.negotiate_value(client_accepts: items, server_offers: ["gzip", "br"])
+  |> should.equal(Some("br"))
+}
+
+pub fn negotiate_encoding_wildcard_test() {
+  let assert Ok(items) = accept.parse_encoding("gzip, *;q=0.1")
+  accept.negotiate_value(client_accepts: items, server_offers: ["br", "gzip"])
+  |> should.equal(Some("gzip"))
+}
+
+pub fn negotiate_charset_q_zero_excludes_test() {
+  let assert Ok(items) = accept.parse_charset("utf-8;q=0, iso-8859-1")
+  accept.negotiate_value(client_accepts: items, server_offers: [
+    "utf-8",
+    "iso-8859-1",
+  ])
+  |> should.equal(Some("iso-8859-1"))
+}
+
+pub fn negotiate_language_test() {
+  let assert Ok(items) = accept.parse_language("en;q=0.9, ja")
+  accept.negotiate_value(client_accepts: items, server_offers: ["en", "ja"])
+  |> should.equal(Some("ja"))
+}
+
+// ---------------------------------------------------------------------------
+// 9. real-world headers
+// ---------------------------------------------------------------------------
+
+pub fn firefox_default_accept_test() {
+  let header =
+    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
+  let assert Ok(items) = accept.parse(header)
+  list.length(items) |> should.equal(6)
+}
+
+pub fn curl_default_accept_test() {
+  let assert Ok(items) = accept.parse("*/*")
+  accept.negotiate(client_accepts: items, server_offers: [
+    mt("application/json"),
+  ])
+  |> should.equal(Some(mt("application/json")))
+}
+
+pub fn json_first_html_fallback_test() {
+  let assert Ok(items) = accept.parse("application/json, text/html;q=0.5")
+  accept.negotiate(client_accepts: items, server_offers: [
+    mt("text/html"),
+    mt("application/json"),
+  ])
+  |> should.equal(Some(mt("application/json")))
+}
+
+pub fn html_with_avif_and_webp_test() {
+  let header =
+    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
+  let assert Ok(items) = accept.parse(header)
+  accept.negotiate(client_accepts: items, server_offers: [
+    mt("application/json"),
+    mt("text/html"),
+  ])
+  |> should.equal(Some(mt("text/html")))
+}


### PR DESCRIPTION
## Summary

Add `mimetype/accept` — a parser and selector for RFC 9110 §12.5 content-negotiation headers (`Accept`, `Accept-Encoding`, `Accept-Charset`, `Accept-Language`). The module exposes a typed AST with q-values, a `prefer` sort, and a `negotiate` function implementing the §12.5.1 proactive-negotiation algorithm so HTTP servers built on `wisp`, `mist`, or raw `gleam_http` can pick the best media type to return for a given client request.

## Changes

- `src/mimetype/accept.gleam` — public facade. `MediaRange` (`Specific(MimeType)` / `TypeWildcard` / `AnyType`), `AcceptItem`, `ValueItem`, `AcceptError`, and the eight public functions (`parse`, `prefer`, `negotiate`, `parse_encoding`, `parse_charset`, `parse_language`, `prefer_values`, `negotiate_value`).
- `src/mimetype/internal/accept.gleam` — quote-aware comma splitter, q-value parser, accept-ext extractor, common token-list parser shared by the three sister headers.
- `src/mimetype/internal/parse.gleam` — promoted `split_on_unquoted_semicolons` to `pub` so the accept internal can reuse it (kept inside `mimetype/internal/*` so it stays out of the public surface).
- `test/mimetype_accept_test.gleam` — 45 tests across nine sections: parse basics, q-value edge cases, quoted parameters, whitespace tolerance, malformed inputs, prefer sorting, negotiate, encoding/charset/language helpers, and four real-world browser/curl fixtures.
- `CHANGELOG.md` — `## [Unreleased]` `### Added` entry.
- `README.md` — new `## Content negotiation` section between `## Capabilities and limitations` and `## Reader-based detection`.

## Design Decisions

- **`Specific(MimeType)` reuses the existing opaque type.** Media-range parameters ride along inside the `MimeType` value, so callers can call `mimetype.parameter_of(...)` on the inner value if they need. No parallel parameter shape.
- **\`q=\` is the boundary** between media-type parameters and accept-ext extensions, per §12.5.1. Located case-insensitively in the per-entry parameter list.
- **Server-preference shortcut.** If the client sends only `*/*` (and q>0), the server's first offer wins — matches RFC guidance and what HTTP servers actually want.
- **`q=0` is exclusion.** Filtered out before the priority compare in both `negotiate` and `negotiate_value`.
- **Essence-only matching for `Specific`.** §12.5.1's parameter-level "more-specific" matching (`text/html; level=1` beating plain `text/html`) is deliberately out of scope; documented in the docstring and README notes. Callers who need it can build on top of `parse`'s output.
- **Stable sort by 3-tuple key.** `prefer` uses `(-q, -specificity, -ext_count)` via `gleam/list.sort` (stable as of stdlib 0.40+; gleam.toml requires ≥0.44.0).
- **No new dependencies.** Pure `gleam_stdlib` — `string`, `list`, `int`, `float`, `result`, `option`, `bool`, `order`. JS-target compatible (no `regexp`).

## Testing

- `mise exec -- just ci` — pass.
- `mise exec -- gleam test --target erlang` — 412 passed (367 existing + 45 new).
- `mise exec -- gleam test --target javascript` — 412 passed.
- `mise exec -- gleam run -m glinter` — no issues (\`warnings_as_errors = true\`).

## Limitations

- Parameter-level matching for \`Specific(MimeType)\` is not implemented (§12.5.1 \"more-specific\" rule).
- RFC 4647 lenient language-tag matching (\`en\` matching \`en-US\`) is exact-string only in v1.

Closes #116