### PR TITLE
chore(release): prepare v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-05-11
+
 ### Added
 
 - `mimetype/accept` — RFC 9110 §12.5 content negotiation

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "mimetype"
-version = "0.18.0"
+version = "0.19.0"
 description = "MIME type lookup and magic-number detection for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "mimetype" }


### PR DESCRIPTION
### Added

- `mimetype/accept` — RFC 9110 §12.5 content negotiation
  parser and selector. Handles `Accept`, `Accept-Encoding`,
  `Accept-Charset`, and `Accept-Language` headers (q-values,
  wildcards `*/*` and `type/*`, accept-ext parameters,
  whitespace tolerance per §5.6.3), and implements the §12.5.1
  proactive-negotiation algorithm via `negotiate/2`. (#116)
