### PR TITLE
fix(parse): reject non-token parameter names per RFC 7230 §3.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `mimetype.parse` now rejects parameter names that are
+  not a valid RFC 9110 §5.6.6 / RFC 7230 §3.2.6 `token`. Inputs such
+  as `"application/json; chars et=utf-8"`,
+  `"application/json; cha\\trset=utf-8"`, or
+  `"application/json; ch a r set=utf-8"` previously parsed to
+  `Ok(_)` with the malformed name round-tripping through
+  `to_string`, which would emit a `Content-Type` header that
+  RFC-strict receivers drop the parameter from. They now return
+  `Error(InvalidParameterName(name))`, carrying the trimmed but
+  non-case-folded offending name. A new
+  `InvalidParameterName(name: String)` variant is added to
+  `ParseError`; existing exhaustive `case` clauses on `ParseError`
+  must add a branch (or rely on the new variant being unreachable
+  for the inputs they actually pass through). Same RFC-strict
+  posture as #88's `valid_essence` fix, now extended to the
+  parameter-name path. (#119)
+
 ## [0.19.0] - 2026-05-11
 
 ### Added

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -43,6 +43,16 @@ pub type ParseError {
   /// by RFC 6838. The original input is carried so the caller can
   /// render it without re-parsing.
   InvalidMimeType(String)
+  /// A parameter name was not a valid RFC 9110 §5.6.6 / RFC 7230
+  /// §3.2.6 `token`. Most commonly this means the name contained
+  /// whitespace (SP, HTAB) or another non-tchar codepoint —
+  /// `"chars et"`, `"cha\tarset"`, etc. Carries the trimmed but
+  /// non-case-folded name so callers can render an actionable error
+  /// like "parameter name 'chars et' contains whitespace".
+  /// Round-tripping such a name through `to_string` would otherwise
+  /// emit a malformed `Content-Type` header that RFC-strict HTTP
+  /// receivers drop the parameter from.
+  InvalidParameterName(name: String)
   /// A parameter value contained an ASCII control byte that is valid
   /// in neither `token` nor `quoted-string` per RFC 7231 §3.1.1.1.
   /// Carries the parameter name and the offending codepoint so the
@@ -124,6 +134,9 @@ pub const default_detection_limit = 3072
 /// - `Error(EmptyMimeType)` for empty / whitespace-only input.
 /// - `Error(InvalidMimeType(original))` when the essence does not
 ///   match the `type/subtype` shape required by RFC 6838.
+/// - `Error(InvalidParameterName(name))` when a parameter name is not
+///   a valid RFC 9110 §5.6.6 / RFC 7230 §3.2.6 `token` (most often
+///   because it contains whitespace or another non-tchar codepoint).
 /// - `Error(InvalidParameterValue(parameter, byte))` when a parameter
 ///   value contains an ASCII control byte that is valid in neither
 ///   `token` nor `quoted-string` per RFC 7231 §3.1.1.1 (0x00-0x1F
@@ -136,6 +149,8 @@ pub fn parse(input: String) -> Result(MimeType, ParseError) {
     Error(parse_internal.Empty) -> Error(EmptyMimeType)
     Error(parse_internal.InvalidEssence(original)) ->
       Error(InvalidMimeType(original))
+    Error(parse_internal.InvalidParameterName(name:)) ->
+      Error(InvalidParameterName(name: name))
     Error(parse_internal.InvalidParameterValue(parameter:, byte:)) ->
       Error(InvalidParameterValue(parameter: parameter, byte: byte))
   }
@@ -578,9 +593,11 @@ fn from_internal(s: String) -> MimeType {
     Error(parse_internal.InvalidEssence(_)) ->
       MimeType(essence: s |> string.trim |> string.lowercase, parameters: [])
     // Internal sources (the magic table, the extension DB) never
-    // include control bytes in parameter values; falling back to the
-    // bare essence here is the conservative path if the data tables
-    // ever drift.
+    // include non-token bytes in parameter names or values; falling
+    // back to the bare essence here is the conservative path if the
+    // data tables ever drift.
+    Error(parse_internal.InvalidParameterName(_)) ->
+      MimeType(essence: s |> string.trim |> string.lowercase, parameters: [])
     Error(parse_internal.InvalidParameterValue(_, _)) ->
       MimeType(essence: s |> string.trim |> string.lowercase, parameters: [])
   }

--- a/src/mimetype/internal/parse.gleam
+++ b/src/mimetype/internal/parse.gleam
@@ -28,6 +28,11 @@ pub type ParseFailure {
   /// Input did not match the `type/subtype` essence shape; carries
   /// the original string for the caller's `InvalidMimeType` payload.
   InvalidEssence(original: String)
+  /// A parameter name was not a valid RFC 7230 §3.2.6 token — most
+  /// often because it contained whitespace (SP, HTAB) or another
+  /// non-tchar codepoint. Carries the offending name (trimmed but
+  /// not case-folded) so the facade can render an actionable error.
+  InvalidParameterName(name: String)
   /// A parameter value contained an ASCII control byte that is valid
   /// in neither `token` nor `quoted-string` per RFC 7231 §3.1.1.1.
   /// `byte` is the offending codepoint (0..31 except 9; or 127);
@@ -176,9 +181,21 @@ fn parse_parameter_segment(
   case string.split_once(seg, on: "=") {
     Error(Nil) -> Ok(acc)
     Ok(#(name, value)) -> {
-      let normalized_name = name |> string.trim |> string.lowercase
+      let trimmed_name = string.trim(name)
+      let normalized_name = string.lowercase(trimmed_name)
       let normalized_value = value |> string.trim |> unquote_value
       use <- bool.guard(when: normalized_name == "", return: Ok(acc))
+      // RFC 9110 §5.6.6 / RFC 7230 §3.2.6: parameter-name = token.
+      // Reject whitespace and other non-tchar codepoints in names so
+      // round-tripping through `serialise` cannot emit a malformed
+      // Content-Type header. The lenient acceptance of trailing `;`,
+      // `;;`, `key` (no `=`), and empty unquoted values is kept here
+      // because those segments are dropped before reaching this
+      // guard.
+      use <- bool.guard(
+        when: !is_token(normalized_name),
+        return: Error(InvalidParameterName(name: trimmed_name)),
+      )
       case forbidden_control_byte(normalized_value) {
         Some(byte) ->
           Error(InvalidParameterValue(parameter: normalized_name, byte: byte))

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -483,6 +483,53 @@ pub fn parse_error_reports_first_offending_parameter_test() {
   )
 }
 
+// Issue #119: parameter names must be valid RFC 9110 §5.6.6 / RFC
+// 7230 §3.2.6 tokens. Whitespace (SP, HTAB) and other non-tchar
+// codepoints are not allowed; previously the parser accepted them
+// and round-tripped the malformed name through `to_string`, which
+// would emit a Content-Type header that RFC-strict receivers drop
+// the parameter from.
+
+pub fn parse_rejects_space_in_parameter_name_test() {
+  mimetype.parse("application/json; chars et=utf-8")
+  |> should.equal(Error(mimetype.InvalidParameterName(name: "chars et")))
+}
+
+pub fn parse_rejects_htab_in_parameter_name_test() {
+  mimetype.parse("application/json; cha\u{0009}rset=utf-8")
+  |> should.equal(Error(mimetype.InvalidParameterName(name: "cha\u{0009}rset")))
+}
+
+pub fn parse_rejects_multiple_spaces_in_parameter_name_test() {
+  mimetype.parse("application/json; ch a r set=utf-8")
+  |> should.equal(Error(mimetype.InvalidParameterName(name: "ch a r set")))
+}
+
+pub fn parse_rejects_non_token_punctuation_in_parameter_name_test() {
+  // Parentheses are HTTP separators and must be rejected as part of a
+  // parameter name even though they appear elsewhere in MIME wire
+  // formats.
+  mimetype.parse("application/json; (charset)=utf-8")
+  |> should.equal(Error(mimetype.InvalidParameterName(name: "(charset)")))
+}
+
+pub fn parse_accepts_token_specials_in_parameter_name_test() {
+  // Every tchar specials character is a valid token codepoint per
+  // RFC 7230 §3.2.6 and must round-trip through parse / to_string.
+  let assert Ok(mt) =
+    mimetype.parse("application/json; weird!#$%&'*+-.^_`|~=utf-8")
+  mt
+  |> mimetype.parameter_of("weird!#$%&'*+-.^_`|~")
+  |> should.equal(Some("utf-8"))
+}
+
+pub fn parse_first_invalid_parameter_name_short_circuits_test() {
+  // The first non-token parameter name in input order is reported;
+  // later parameters (even with their own problems) don't matter.
+  mimetype.parse("application/json; bad name=utf-8; charset=\u{0001}")
+  |> should.equal(Error(mimetype.InvalidParameterName(name: "bad name")))
+}
+
 pub fn parse_accepts_valid_token_essence_test() {
   // Tokens with all the printable-ASCII tchar specials must still pass.
   let assert Ok(mt) = mimetype.parse("application/vnd.api+json")


### PR DESCRIPTION
## Summary

Fixes #119 — `mimetype.parse` accepted parameter names containing whitespace (SP, HTAB) or other non-`tchar` codepoints, and round-tripped the malformed name verbatim through `to_string`. Per RFC 9110 §5.6.6 / RFC 7230 §3.2.6, a parameter name must be a `1*tchar` token. The downstream consequence was an emitted `Content-Type` header that RFC-strict HTTP receivers parse as just the essence, silently losing the charset/profile/etc. parameter.

This is the symmetric fix to #88, which closed the same class of bug on the `type/subtype` essence path.

## Changes

- `src/mimetype/internal/parse.gleam`: new `InvalidParameterName(name: String)` `ParseFailure` variant; `parse_parameter_segment` validates the trimmed + case-folded name against `is_token` after non-empty / has-`=` filtering, so the lenient acceptance of `;`, `;;`, and bare `key` segments is preserved. The error carries the trimmed (non-lowercased) name for diagnostic readability.
- `src/mimetype.gleam`: new `InvalidParameterName(name: String)` public `ParseError` variant; `parse/1` translates the internal failure; `from_internal/1` adds a branch mapping the new variant to the bare-essence conservative path (same as for `InvalidEssence` and `InvalidParameterValue`).
- `test/mimetype_test.gleam`: regression tests for SP, HTAB, multiple internal spaces, non-token punctuation (`()`), the round-trippable tchar-specials happy path (`weird!#$%&'*+-.^_\`|~`), and short-circuit behaviour when a later parameter would have failed for a different reason.
- `CHANGELOG.md`: noted under `[Unreleased]` as **BREAKING** (exhaustive `case` clauses on `ParseError` must add a branch).

## Test plan

- `gleam test --target erlang` — 418 passed, no failures.
- `gleam format --check src/ test/`, `gleam run -m glinter`, `gleam check` all clean.

## Notes

The related observations the issue author flagged (empty unquoted values, `;;`, trailing `;`, bare `key` without `=`) are intentionally left out of this PR to keep scope tight; happy to follow them up in a separate change.

Closes #119
