### PR TITLE
fix(parameter_of, charset_of_type): collapse empty values to None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `mimetype.parameter_of` and `mimetype.charset_of_type` now return `None` when the stored parameter value is the empty string (e.g. `text/plain; charset=`). RFC 9110 / RFC 7230 define `parameter-value` as `token / quoted-string`, both of which require at least one octet — `Some("")` would imply a value the grammar does not permit and breaks the implicit "`Some(_)` means meaningful content" contract that callers assume. `mimetype.parse` itself remains lenient: the empty-valued parameter is still stored and survives a `to_string` round-trip as the empty quoted-string `""`. (#126)
+
 ## [0.21.0] - 2026-05-16
 
 ### Added

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -213,13 +213,19 @@ pub fn essence_of(mt: MimeType) -> String {
 ///   Whitespace *inside* a quoted-string is part of the value and is
 ///   preserved verbatim (`text/plain; description="hello world"` →
 ///   `Some("hello world")`).
+/// - **Empty values**: an empty parameter value (e.g.
+///   `text/plain; charset=`) is collapsed to `None`. RFC 9110 / RFC 7230
+///   define `parameter-value` as `token / quoted-string`, both of which
+///   require at least one octet, so `Some("")` would imply a value that
+///   the grammar does not actually permit. Callers reading `Some(_)` can
+///   then assume the wrapped string carries information.
 pub fn parameter_of(mt: MimeType, key: String) -> Option(String) {
   let requested = key |> string.trim |> string.lowercase
   use <- bool.lazy_guard(when: requested == "", return: fn() { None })
   mt.parameters
   |> list.find_map(fn(p) {
     let #(name, value) = p
-    case name == requested {
+    case name == requested && value != "" {
       True -> Ok(value)
       False -> Error(Nil)
     }

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -236,6 +236,29 @@ pub fn charset_of_type_returns_none_when_missing_test() {
   |> should.equal(None)
 }
 
+// #126: an empty parameter value (`charset=` with no token after `=`) is
+// not a valid `parameter-value` per the RFC grammar — both `token` and
+// `quoted-string` require at least one octet. Collapse it to `None` so
+// the `Option(String)` contract ("present means meaningful") holds.
+
+pub fn parameter_of_returns_none_for_empty_value_test() {
+  mt("text/plain; charset=")
+  |> mimetype.parameter_of("charset")
+  |> should.equal(None)
+}
+
+pub fn charset_of_type_returns_none_for_empty_value_test() {
+  mt("text/plain; charset=")
+  |> mimetype.charset_of_type
+  |> should.equal(None)
+}
+
+pub fn parameter_of_returns_none_for_empty_quoted_value_test() {
+  mt("text/plain; charset=\"\"")
+  |> mimetype.parameter_of("charset")
+  |> should.equal(None)
+}
+
 // RFC 7230 §3.2.6: parameter values may be expressed as quoted-string
 // (DQUOTE qdtext DQUOTE). The surrounding `"` are syntax, not part of
 // the value, so the parser must strip them.
@@ -327,13 +350,16 @@ pub fn to_string_escapes_inner_backslash_test() {
 }
 
 pub fn to_string_quotes_empty_parameter_value_test() {
-  // Empty value is not a valid token (`1*tchar`), so it must be
-  // serialised as the empty quoted-string `""`.
+  // Empty value is not a valid token (`1*tchar`), so on serialisation
+  // the parameter is emitted as the empty quoted-string `""`. The
+  // round-trip survives, but `parameter_of` collapses the empty value
+  // to `None` per #126 (an empty `parameter-value` is not legal in the
+  // RFC grammar; `Some(_)` is reserved for meaningful content).
   let assert Ok(mt1) = mimetype.parse("application/json; tag=\"\"")
   let serialised = mimetype.to_string(mt1)
   let assert Ok(mt2) = mimetype.parse(serialised)
   mimetype.parameter_of(mt2, "tag")
-  |> should.equal(Some(""))
+  |> should.equal(None)
 }
 
 pub fn to_string_leaves_token_value_unquoted_test() {


### PR DESCRIPTION
## Summary

`mimetype.charset_of_type(parse(\"text/plain; charset=\")) == Some(\"\")` violated the implicit contract that `Option(String)` carries — `Some(_)` should mean "present with a meaningful value". RFC 9110 / RFC 7230 define `parameter-value` as `token / quoted-string`, both of which require at least one octet, so an empty value is not actually a legal `parameter-value` to surface. The fix collapses the empty value to `None` at the accessor layer while keeping the parser lenient.

## Changes

- `src/mimetype.gleam`: `parameter_of` now filters out parameters whose stored value is `""`. `charset_of_type` delegates to `parameter_of`, so it inherits the same behaviour. Docstring on `parameter_of` updated with a new bullet documenting the empty-value rule and the RFC rationale.
- `test/mimetype_test.gleam`: added `parameter_of_returns_none_for_empty_value_test`, `charset_of_type_returns_none_for_empty_value_test`, and `parameter_of_returns_none_for_empty_quoted_value_test` to pin the new contract. Updated `to_string_quotes_empty_parameter_value_test` (which previously pinned `Some(\"\")` round-trip) to assert `None` — the round-trip itself still works (parameter is emitted as `\"\"` on serialise), only the accessor result changes.
- `CHANGELOG.md`: `### Changed` entry under `[Unreleased]`.

## Design decisions

- **Helper-side fix, not parser-side.** The issue presented two options: (A) reject `text/plain; charset=` at `parse` time, (B) collapse empty values at the accessor layer. (B) is non-breaking for the parser surface — callers that round-trip MIME strings still get the empty-quoted-string back from `to_string` — and matches the existing pattern where `parameter_of` already normalises (lowercased name, stripped whitespace, unescaped backslashes).
- **Both `parameter_of` and `charset_of_type` updated.** The issue specifically called out `charset_of_type`, but `parameter_of` is the lower-level primitive that exhibits the same shape (`Some(\"\")` for any empty parameter, not just charset). Fixing both keeps the `Option(String)` invariant consistent.
- **No new `parameter_of_raw` variant.** The issue mentioned this as a hypothetical for callers that genuinely want to see empty values, but no caller has surfaced needing one — adding it speculatively would just expand the API.

Closes #126