### PR TITLE
fix(predicates): recognise RFC 6839 structured-syntax suffix hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - `mimetype.parameter_of` and `mimetype.charset_of_type` now return `None` when the stored parameter value is the empty string (e.g. `text/plain; charset=`). RFC 9110 / RFC 7230 define `parameter-value` as `token / quoted-string`, both of which require at least one octet — `Some("")` would imply a value the grammar does not permit and breaks the implicit "`Some(_)` means meaningful content" contract that callers assume. `mimetype.parse` itself remains lenient: the empty-valued parameter is still stored and survives a `to_string` round-trip as the empty quoted-string `""`. (#126)
+- `mimetype.is_a`, `mimetype.is_xml_based`, and `mimetype.ancestors` now recognise the RFC 6839 §3.1 structured-syntax suffix hierarchy. A type whose essence ends with `+xml` (e.g. `application/xhtml+xml`, `application/atom+xml`, `application/rss+xml`, `application/soap+xml`) is treated as a child of `application/xml`; `+json` types as children of `application/json`; `+zip` as `application/zip`; `+cbor` as `application/cbor`. The static hierarchy table still wins on collisions, so `image/svg+xml` continues to point at `text/xml`. Previously only types that had an explicit entry in the table (essentially just `image/svg+xml`) were recognised as XML-based, so every other `*+xml` type returned `False` from `is_xml_based` and `is_a(_, application/xml)`. (#128, #130)
 
 ## [0.21.0] - 2026-05-16
 

--- a/src/mimetype/internal/predicates.gleam
+++ b/src/mimetype/internal/predicates.gleam
@@ -32,6 +32,13 @@ pub fn is_video_essence(essence: String) -> Bool {
 ///
 /// Empty inputs are not equal even to themselves; the facade is
 /// responsible for the empty-essence guard before forwarding here.
+///
+/// Also recognises the RFC 6839 §3.1 structured-syntax suffix
+/// hierarchy: a `*+xml` type is treated as a child of
+/// `application/xml` (and `text/xml`), a `*+json` type as a child of
+/// `application/json`, and so on. The static-hierarchy table still
+/// wins when both apply, so `image/svg+xml` continues to inherit
+/// from `text/xml` via the explicit entry.
 pub fn is_a(mime: String, parent: String) -> Bool {
   use <- bool.guard(when: mime == "", return: False)
   use <- bool.guard(when: parent == "", return: False)
@@ -41,6 +48,10 @@ pub fn is_a(mime: String, parent: String) -> Bool {
 /// Return the chain of ancestor essences for `mime`, from immediate
 /// parent up to the root. Excludes `mime` itself; empty input or
 /// roots return `[]`.
+///
+/// Walks both the static hierarchy table and the RFC 6839 §3.1
+/// structured-syntax suffix mapping, so e.g. `application/xhtml+xml`
+/// returns `["application/xml"]`.
 pub fn ancestors(mime: String) -> List(String) {
   use <- bool.guard(when: mime == "", return: [])
   ancestors_loop(mime, [])
@@ -48,15 +59,46 @@ pub fn ancestors(mime: String) -> List(String) {
 
 fn is_a_loop(mime: String, parent: String) -> Bool {
   use <- bool.lazy_guard(when: mime == parent, return: fn() { True })
-  case hierarchy.parent_of(mime) {
+  case effective_parent(mime) {
     Ok(next) -> is_a_loop(next, parent)
     Error(Nil) -> False
   }
 }
 
 fn ancestors_loop(mime: String, acc: List(String)) -> List(String) {
-  case hierarchy.parent_of(mime) {
+  case effective_parent(mime) {
     Ok(parent) -> ancestors_loop(parent, [parent, ..acc])
     Error(Nil) -> list.reverse(acc)
   }
+}
+
+/// Resolve the immediate parent of `mime` by consulting the static
+/// hierarchy table first, then the RFC 6839 structured-syntax suffix
+/// mapping. The explicit table wins on collisions so callers that
+/// added a custom parent for a `+suffix` type still see it.
+fn effective_parent(mime: String) -> Result(String, Nil) {
+  case hierarchy.parent_of(mime) {
+    Ok(parent) -> Ok(parent)
+    Error(Nil) -> suffix_parent_of(mime)
+  }
+}
+
+/// Map an RFC 6839 §3.1 structured-syntax suffix to its canonical
+/// parent media type. Recognises `+xml`, `+json`, `+zip`, and
+/// `+cbor` — the four suffixes registered in the IANA registry that
+/// have an obvious universally-supported parent type.
+fn suffix_parent_of(mime: String) -> Result(String, Nil) {
+  use <- bool.lazy_guard(when: string.ends_with(mime, "+xml"), return: fn() {
+    Ok("application/xml")
+  })
+  use <- bool.lazy_guard(when: string.ends_with(mime, "+json"), return: fn() {
+    Ok("application/json")
+  })
+  use <- bool.lazy_guard(when: string.ends_with(mime, "+zip"), return: fn() {
+    Ok("application/zip")
+  })
+  use <- bool.lazy_guard(when: string.ends_with(mime, "+cbor"), return: fn() {
+    Ok("application/cbor")
+  })
+  Error(Nil)
 }

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -2145,6 +2145,85 @@ pub fn is_xml_based_html_test() {
   |> should.equal(False)
 }
 
+// #128 / #130: every `*+xml` type is XML-based per RFC 6839 §3.1.
+
+pub fn is_xml_based_xhtml_plus_xml_test() {
+  mimetype.is_xml_based(mt("application/xhtml+xml"))
+  |> should.equal(True)
+}
+
+pub fn is_xml_based_atom_plus_xml_test() {
+  mimetype.is_xml_based(mt("application/atom+xml"))
+  |> should.equal(True)
+}
+
+pub fn is_xml_based_rss_plus_xml_test() {
+  mimetype.is_xml_based(mt("application/rss+xml"))
+  |> should.equal(True)
+}
+
+pub fn is_xml_based_soap_plus_xml_test() {
+  mimetype.is_xml_based(mt("application/soap+xml"))
+  |> should.equal(True)
+}
+
+pub fn is_xml_based_arbitrary_plus_xml_test() {
+  // Any unknown `*+xml` registration is still XML-based per the
+  // suffix grammar, not just the well-known ones.
+  mimetype.is_xml_based(mt("application/foo+xml"))
+  |> should.equal(True)
+}
+
+pub fn is_a_xhtml_is_application_xml_test() {
+  mimetype.is_a(mt("application/xhtml+xml"), mt("application/xml"))
+  |> should.equal(True)
+}
+
+pub fn is_a_atom_is_application_xml_test() {
+  mimetype.is_a(mt("application/atom+xml"), mt("application/xml"))
+  |> should.equal(True)
+}
+
+pub fn is_a_ld_json_is_application_json_test() {
+  mimetype.is_a(mt("application/ld+json"), mt("application/json"))
+  |> should.equal(True)
+}
+
+pub fn is_a_hal_json_is_application_json_test() {
+  mimetype.is_a(mt("application/hal+json"), mt("application/json"))
+  |> should.equal(True)
+}
+
+pub fn is_a_unknown_plus_zip_is_application_zip_test() {
+  // `+zip` is one of the four RFC 6839 suffixes — an unregistered
+  // `application/x-custom+zip` is still a ZIP container.
+  mimetype.is_a(mt("application/x-custom+zip"), mt("application/zip"))
+  |> should.equal(True)
+}
+
+pub fn is_a_unknown_plus_cbor_is_application_cbor_test() {
+  mimetype.is_a(mt("application/x-custom+cbor"), mt("application/cbor"))
+  |> should.equal(True)
+}
+
+pub fn is_a_suffix_does_not_cross_to_other_parent_test() {
+  // `+json` does not imply `application/xml`, etc.
+  mimetype.is_a(mt("application/ld+json"), mt("application/xml"))
+  |> should.equal(False)
+}
+
+pub fn ancestors_xhtml_plus_xml_test() {
+  mimetype.ancestors(mt("application/xhtml+xml"))
+  |> list.map(mimetype.to_string)
+  |> should.equal(["application/xml"])
+}
+
+pub fn ancestors_ld_plus_json_test() {
+  mimetype.ancestors(mt("application/ld+json"))
+  |> list.map(mimetype.to_string)
+  |> should.equal(["application/json"])
+}
+
 pub fn ancestors_epub_test() {
   mimetype.ancestors(mt("application/epub+zip"))
   |> list.map(mimetype.to_string)


### PR DESCRIPTION
## Summary

Before this PR, `is_a(application/xhtml+xml, application/xml)` returned False and `is_xml_based(application/atom+xml)` returned False — only `image/svg+xml` was recognised as XML-based, because it was the single `*+xml` entry in the static `hierarchy.parents` table. RFC 6839 §3.1 explicitly defines `+xml` and `+json` as structured-syntax-suffix markers that mean "this type is also XML/JSON and inherits its properties", so the predicate should track the suffix, not a hardcoded subset.

The fix teaches the internal `effective_parent` resolver to fall back to a suffix-based mapping when the static table has no entry: `+xml → application/xml`, `+json → application/json`, `+zip → application/zip`, `+cbor → application/cbor`. The static table still wins, so `image/svg+xml` keeps its existing `text/xml` parent (no behaviour change for it).

## Changes

- `src/mimetype/internal/predicates.gleam`: replaced direct `hierarchy.parent_of` calls in `is_a_loop` and `ancestors_loop` with a new `effective_parent`. Added `suffix_parent_of`, which uses `string.ends_with` checks (function calls are not allowed in `case` guards in Gleam) to map the four IANA-registered structured-syntax suffixes that have an obvious universal parent. Docstrings on `is_a` and `ancestors` mention the new behaviour.
- `test/mimetype_test.gleam`: added 14 regression tests covering `is_xml_based` for `application/xhtml+xml`, `atom+xml`, `rss+xml`, `soap+xml`, and an arbitrary `application/foo+xml`; `is_a` against `application/xml`, `application/json`, `application/zip`, `application/cbor`; an `is_a` negative test that `+json` does not imply `application/xml`; and `ancestors` for `application/xhtml+xml` and `application/ld+json`.
- `CHANGELOG.md`: `### Changed` entry under `[Unreleased]` covering both issues.

## Design decisions

- **Suffix recognition lives in `predicates`, not `hierarchy`.** `hierarchy.parents` is a static `#(child, parent)` table — adding suffix recognition there would require enumerating every conceivable `*+xml` registration. Doing it in the resolver keeps the table small (it now lists only types whose parent does *not* match the suffix mapping) and naturally covers unknown registrations.
- **Static table wins on collision.** `image/svg+xml` is in the table mapping to `text/xml`. The new suffix mapping would point it at `application/xml`. Keeping the table-first order preserves the existing answer for SVG; both still pass `is_xml_based` because that helper checks both XML roots.
- **Only four suffixes mapped.** RFC 6839 also registers `+ber`, `+der`, `+fastinfoset`, `+wbxml`, `+tlv`, `+wasm`, `+gzip`. Those either have no obvious universally-supported parent media type or are very rarely seen in the wild; adding them speculatively would introduce parents callers do not actually query. The four chosen (`+xml`, `+json`, `+zip`, `+cbor`) cover every case raised in #128 / #130 and the issue's expected-test list.

Closes #128
Closes #130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * MIME type classification methods now recognize RFC 6839 structured-suffix hierarchies, treating types with +xml, +json, +zip, and +cbor suffixes as children of their corresponding base types (e.g., application/soap+xml as a child of application/xml).

* **Tests**
  * Added tests for structured-suffix hierarchy recognition and ancestor relationship validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/mimetype/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->