### PR TITLE
chore(release): prepare v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-05-20
+
 ### Changed
 
 - `mimetype.parameter_of` and `mimetype.charset_of_type` now return `None` when the stored parameter value is the empty string (e.g. `text/plain; charset=`). RFC 9110 / RFC 7230 define `parameter-value` as `token / quoted-string`, both of which require at least one octet — `Some("")` would imply a value the grammar does not permit and breaks the implicit "`Some(_)` means meaningful content" contract that callers assume. `mimetype.parse` itself remains lenient: the empty-valued parameter is still stored and survives a `to_string` round-trip as the empty quoted-string `""`. (#126)

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "mimetype"
-version = "0.21.0"
+version = "0.22.0"
 description = "MIME type lookup and magic-number detection for Gleam on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "mimetype" }


### PR DESCRIPTION
### Changed

- `mimetype.parameter_of` and `mimetype.charset_of_type` now return `None` when the stored parameter value is the empty string (e.g. `text/plain; charset=`). RFC 9110 / RFC 7230 define `parameter-value` as `token / quoted-string`, both of which require at least one octet — `Some("")` would imply a value the grammar does not permit and breaks the implicit "`Some(_)` means meaningful content" contract that callers assume. `mimetype.parse` itself remains lenient: the empty-valued parameter is still stored and survives a `to_string` round-trip as the empty quoted-string `""`. (#126)
- `mimetype.is_a`, `mimetype.is_xml_based`, and `mimetype.ancestors` now recognise the RFC 6839 §3.1 structured-syntax suffix hierarchy. A type whose essence ends with `+xml` (e.g. `application/xhtml+xml`, `application/atom+xml`, `application/rss+xml`, `application/soap+xml`) is treated as a child of `application/xml`; `+json` types as children of `application/json`; `+zip` as `application/zip`; `+cbor` as `application/cbor`. The static hierarchy table still wins on collisions, so `image/svg+xml` continues to point at `text/xml`. Previously only types that had an explicit entry in the table (essentially just `image/svg+xml`) were recognised as XML-based, so every other `*+xml` type returned `False` from `is_xml_based` and `is_a(_, application/xml)`. (#128, #130)
- `mimetype.is_text` now returns `True` for `application/json`, `application/xml`, `application/javascript`, `application/ecmascript`, `application/sql`, `application/x-sql`, and every RFC 6839 §3.1 `*+json` / `*+xml` structured-syntax-suffix type, in addition to the `text/*` family. RFC 8259 §8.1 mandates that JSON be UTF-8 / UTF-16 / UTF-32 encoded, and browsers / HTTP intermediaries / log viewers / editors all treat JSON and XML as text — the previous strictly-`text/*` predicate forced every caller to write its own "is this safe to decode as a string?" override. Callers that want the old strictly-`text/*` semantics can use `string.starts_with(mimetype.essence_of(mt), "text/")` directly. (#129)
- `mimetype.mime_type_to_extensions(audio/mp3)` and `mimetype.mime_type_to_extensions_strict(audio/mp3)` now return the same six extensions (`mpga`, `mp2`, `mp2a`, `mp3`, `m2a`, `m3a`) as `audio/mpeg` instead of the truncated `["mp3"]` list. `audio/mp3` is widely used in browsers and HTML5 audio but is not IANA-registered; the canonical name for the same payload is `audio/mpeg`. An internal alias table in `mimetype/internal/lookup` canonicalises the spelling before the FFI lookup, so the choice of MIME string no longer silently reduces the extension set. (#131)

### Added

- `mimetype/accept.negotiate_strings`, `accept.negotiate_encoding_strings`, `accept.negotiate_charset_strings`, and `accept.negotiate_language_strings` — convenience wrappers that take the client header and the server offers as raw strings, returning the selected offer **verbatim** from the supplied list. The new `accept.NegotiateError` type distinguishes `InvalidHeader(reason: AcceptError)` (route to `400 Bad Request`), `InvalidOffer(raw: String)` (server-configuration bug → `500`), and `NoOverlap` (`406 Not Acceptable`). The previous three-step ceremony (`accept.parse` → `mimetype.parse` × n → `negotiate` → render) collapses into a single call for the HTTP server case where both sides arrive as strings. (#125)

### Fixed

- `mimetype.detect_with_extension` and `mimetype.detect_with_filename` no longer let a binary-claiming extension override text-shaped byte content. Previously, plain ASCII bytes with a `.png` extension returned `image/png` because the extension was consulted before the printable-ASCII heuristic; the same shape was the foundation of a security risk in upload pipelines where the extension is attacker-controlled (an image renderer / validator would process a text payload as if it were an image). Now: genuine byte signatures still win first; the extension is then reconciled with the byte-level text heuristic so that a text-treatable extension (e.g. `.csv`) keeps overriding the heuristic for specificity, but a binary-claiming extension (`.png`, `.zip`, `.jpg`) loses to bytes-as-text. JSON / XML / structural-sniff signatures are unaffected — they were already detected before the extension was consulted. (#127)
