### PR TITLE
feat(mimetype): add parse_strict for RFC-strict parameter lists (closes #143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `mimetype.parse_strict(input) -> Result(MimeType, ParseError)` — strict counterpart of `parse/1` that rejects the RFC 7231 §3.1.1.1 parameter-list violations the lenient parser silently drops: a trailing / bare / consecutive `;` (empty segment), a parameter with no `=value`, and an empty parameter name (`;=value`). These now return `Error(MalformedParameter(segment))`, naming the offending segment, instead of being thrown away — so callers validating a configuration value, a manifest field, or test fixtures can tell "no parameters" from "three malformed parameters we dropped". `parse/1` stays lenient by design (real-world HTTP `Content-Type` headers carry stray semicolons and whitespace) and is unchanged. A new `MalformedParameter(segment: String)` variant is added to `ParseError`. (#143)
+
 ## [0.23.0] - 2026-05-22
 
 ### Fixed

--- a/src/mimetype.gleam
+++ b/src/mimetype.gleam
@@ -61,6 +61,13 @@ pub type ParseError {
   /// Allowed: HTAB (0x09) and every byte at or above 0x20 except DEL
   /// (0x7F). Rejected: 0x00-0x08, 0x0A-0x1F, 0x7F.
   InvalidParameterValue(parameter: String, byte: Int)
+  /// A `;`-separated segment was not a well-formed `name=value`
+  /// parameter — a trailing / bare / consecutive `;` (empty segment),
+  /// a segment with no `=value`, or an empty parameter name (`;=v`) —
+  /// all RFC 7231 §3.1.1.1 violations. Only `parse_strict/1` returns
+  /// this; the lenient `parse/1` silently drops such segments. Carries
+  /// the offending segment (trimmed).
+  MalformedParameter(segment: String)
 }
 
 /// Reasons the strict detection family can return `Error(_)`.
@@ -155,7 +162,32 @@ pub const default_detection_limit = 3072
 ///   except HTAB `0x09`, and DEL `0x7F`). These bytes would produce
 ///   a malformed `Content-Type` header on the wire.
 pub fn parse(input: String) -> Result(MimeType, ParseError) {
-  case parse_internal.parse_string(input) {
+  parse_internal.parse_string(input) |> map_parse_result
+}
+
+/// Strict counterpart of [`parse/1`](#parse). In addition to everything
+/// `parse` rejects, each `;`-separated segment MUST be a well-formed
+/// `name=value` parameter per RFC 7231 §3.1.1.1 — a trailing / bare /
+/// consecutive `;`, a segment with no `=value`, and an empty parameter
+/// name are rejected with `Error(MalformedParameter(segment))` instead of
+/// being silently dropped.
+///
+/// `parse/1` stays lenient because real-world HTTP `Content-Type` headers
+/// commonly carry stray semicolons and whitespace; reach for `parse_strict`
+/// when the input must conform to the RFC grammar exactly (validating a
+/// configuration value, a manifest field, or test fixtures), so a malformed
+/// parameter list is reported rather than quietly thrown away.
+pub fn parse_strict(input: String) -> Result(MimeType, ParseError) {
+  parse_internal.parse_string_strict(input) |> map_parse_result
+}
+
+fn map_parse_result(
+  result: Result(
+    #(String, List(#(String, String))),
+    parse_internal.ParseFailure,
+  ),
+) -> Result(MimeType, ParseError) {
+  case result {
     Ok(#(essence, parameters)) ->
       Ok(MimeType(essence: essence, parameters: parameters))
     Error(parse_internal.Empty) -> Error(EmptyMimeType)
@@ -165,6 +197,8 @@ pub fn parse(input: String) -> Result(MimeType, ParseError) {
       Error(InvalidParameterName(name: name))
     Error(parse_internal.InvalidParameterValue(parameter:, byte:)) ->
       Error(InvalidParameterValue(parameter: parameter, byte: byte))
+    Error(parse_internal.MalformedParameter(segment:)) ->
+      Error(MalformedParameter(segment: segment))
   }
 }
 
@@ -667,6 +701,10 @@ fn from_internal(s: String) -> MimeType {
     Error(parse_internal.InvalidParameterName(_)) ->
       MimeType(essence: s |> string.trim |> string.lowercase, parameters: [])
     Error(parse_internal.InvalidParameterValue(_, _)) ->
+      MimeType(essence: s |> string.trim |> string.lowercase, parameters: [])
+    // `parse_string` is the lenient parser and never emits this, but the
+    // match must stay exhaustive — fall back to the bare essence too.
+    Error(parse_internal.MalformedParameter(_)) ->
       MimeType(essence: s |> string.trim |> string.lowercase, parameters: [])
   }
 }

--- a/src/mimetype/internal/parse.gleam
+++ b/src/mimetype/internal/parse.gleam
@@ -39,6 +39,12 @@ pub type ParseFailure {
   /// `parameter` is the parameter name whose value was rejected so
   /// the caller can render an actionable error.
   InvalidParameterValue(parameter: String, byte: Int)
+  /// A `;`-separated segment was not a well-formed `name=value`
+  /// parameter — a trailing / bare / consecutive `;` (empty segment),
+  /// a segment with no `=value`, or an empty parameter name (`;=v`).
+  /// Only the strict parse path emits this; the lenient path drops
+  /// such segments. Carries the offending segment (trimmed).
+  MalformedParameter(segment: String)
 }
 
 /// Parse a wire-format MIME string into its essence + parameter list.
@@ -52,6 +58,24 @@ pub type ParseFailure {
 pub fn parse_string(
   input: String,
 ) -> Result(#(String, List(#(String, String))), ParseFailure) {
+  parse_string_with(input, strict: False)
+}
+
+/// Strict variant of [`parse_string`](#parse_string): each `;`-separated
+/// segment MUST be a well-formed `name=value` parameter per RFC 7231
+/// §3.1.1.1. A trailing / bare / consecutive `;`, a segment with no
+/// `=value`, and an empty parameter name are rejected with
+/// `MalformedParameter(segment)` instead of being silently dropped.
+pub fn parse_string_strict(
+  input: String,
+) -> Result(#(String, List(#(String, String))), ParseFailure) {
+  parse_string_with(input, strict: True)
+}
+
+fn parse_string_with(
+  input: String,
+  strict strict: Bool,
+) -> Result(#(String, List(#(String, String))), ParseFailure) {
   let trimmed = string.trim(input)
   use <- bool.guard(when: trimmed == "", return: Error(Empty))
   case split_on_unquoted_semicolons(trimmed) {
@@ -62,7 +86,7 @@ pub fn parse_string(
         when: !valid_essence(essence_value),
         return: Error(InvalidEssence(input)),
       )
-      case parse_parameters(rest) {
+      case parse_parameters(rest, strict) {
         Ok(parameters) -> Ok(#(essence_value, parameters))
         Error(e) -> Error(e)
       }
@@ -164,27 +188,40 @@ fn is_tchar(cp: Int) -> Bool {
 
 fn parse_parameters(
   segments: List(String),
+  strict: Bool,
 ) -> Result(List(#(String, String)), ParseFailure) {
   segments
-  |> list.try_fold([], parse_parameter_segment)
+  |> list.try_fold([], fn(acc, seg) {
+    parse_parameter_segment(acc, seg, strict)
+  })
   |> result.map(list.reverse)
 }
 
-// Same lenience as the previous `list.filter_map` shape for
-// non-`name=value` and empty-name segments — a stray `;` mid-string
-// should not abort the parse. Forbidden control bytes inside a value
-// abort, naming the offending parameter.
+// Lenient (`strict: False`): non-`name=value` and empty-name segments are
+// dropped so a stray `;` mid-string does not abort the parse — the
+// behaviour real-world HTTP `Content-Type` headers rely on. Strict
+// (`strict: True`, via `parse_string_strict`): the same segments are
+// rejected with `MalformedParameter` per RFC 7231 §3.1.1.1. Forbidden
+// control bytes inside a value abort in both modes, naming the parameter.
 fn parse_parameter_segment(
   acc: List(#(String, String)),
   seg: String,
+  strict: Bool,
 ) -> Result(List(#(String, String)), ParseFailure) {
   case string.split_once(seg, on: "=") {
-    Error(Nil) -> Ok(acc)
+    Error(Nil) ->
+      case strict {
+        True -> Error(MalformedParameter(segment: string.trim(seg)))
+        False -> Ok(acc)
+      }
     Ok(#(name, value)) -> {
       let trimmed_name = string.trim(name)
       let normalized_name = string.lowercase(trimmed_name)
       let normalized_value = value |> string.trim |> unquote_value
-      use <- bool.guard(when: normalized_name == "", return: Ok(acc))
+      use <- bool.guard(when: normalized_name == "", return: case strict {
+        True -> Error(MalformedParameter(segment: string.trim(seg)))
+        False -> Ok(acc)
+      })
       // RFC 9110 §5.6.6 / RFC 7230 §3.2.6: parameter-name = token.
       // Reject whitespace and other non-tchar codepoints in names so
       // round-tripping through `serialise` cannot emit a malformed

--- a/test/mimetype_test.gleam
+++ b/test/mimetype_test.gleam
@@ -2688,3 +2688,65 @@ pub fn detect_with_filename_handles_path_components_test() {
   mimetype.detect_with_filename(<<>>, "/tmp/files/note.pdf")
   |> should_be_mime("application/pdf")
 }
+
+// Issue #143: parse_strict rejects the RFC 7231 §3.1.1.1 parameter-list
+// violations that lenient `parse` silently drops — a trailing `;` with no
+// parameter, a parameter missing its `=value`, and an empty parameter name.
+// `parse` stays lenient by design (real HTTP Content-Type headers carry
+// stray semicolons); these tests pin both halves so neither contract drifts.
+
+pub fn parse_strict_rejects_trailing_semicolon_test() {
+  let assert Error(mimetype.MalformedParameter(_)) =
+    mimetype.parse_strict("text/plain; ")
+}
+
+pub fn parse_strict_rejects_bare_semicolon_test() {
+  let assert Error(mimetype.MalformedParameter(_)) =
+    mimetype.parse_strict("text/plain;")
+}
+
+pub fn parse_strict_rejects_consecutive_semicolons_test() {
+  let assert Error(mimetype.MalformedParameter(_)) =
+    mimetype.parse_strict("text/plain; charset=utf-8;;")
+}
+
+pub fn parse_strict_rejects_missing_equals_test() {
+  let assert Error(mimetype.MalformedParameter(_)) =
+    mimetype.parse_strict("text/plain; key")
+}
+
+pub fn parse_strict_rejects_empty_parameter_name_test() {
+  let assert Error(mimetype.MalformedParameter(_)) =
+    mimetype.parse_strict("text/plain;=value")
+}
+
+pub fn parse_strict_accepts_well_formed_parameters_test() {
+  mimetype.parse_strict("text/plain; charset=utf-8")
+  |> result.map(mimetype.to_string)
+  |> should.equal(Ok("text/plain; charset=utf-8"))
+}
+
+pub fn parse_strict_accepts_no_parameters_test() {
+  mimetype.parse_strict("text/plain")
+  |> result.map(mimetype.to_string)
+  |> should.equal(Ok("text/plain"))
+}
+
+// parse_strict still surfaces the existing strict checks.
+pub fn parse_strict_still_rejects_non_token_name_test() {
+  let assert Error(mimetype.InvalidParameterName(_)) =
+    mimetype.parse_strict("text/plain; chars et=utf-8")
+}
+
+// Lenient parse keeps dropping the malformed segments (documented contract).
+pub fn parse_lenient_drops_malformed_parameters_test() {
+  mimetype.parse("text/plain; ")
+  |> result.map(mimetype.to_string)
+  |> should.equal(Ok("text/plain"))
+  mimetype.parse("text/plain; key")
+  |> result.map(mimetype.to_string)
+  |> should.equal(Ok("text/plain"))
+  mimetype.parse("text/plain;=value")
+  |> result.map(mimetype.to_string)
+  |> should.equal(Ok("text/plain"))
+}


### PR DESCRIPTION
## Summary

`mimetype.parse` silently accepts three RFC 7231 §3.1.1.1 parameter-list violations: a trailing semicolon with no parameter, a parameter that omits the `=value` half, and a parameter with an empty name (`;=value`). All three are dropped, so the result is indistinguishable from `text/plain` with no parameters — the caller can't tell "no parameters" from "three malformed parameters we threw away".

## Decision

The lenient acceptance is deliberate — the parser's own comment notes real-world HTTP `Content-Type` headers carry stray semicolons and whitespace, so making `parse` strict would break HTTP-receiving code. The issue's suggested resolution (and the path taken here) is a `parse_strict` companion, which also matches the package's established `_strict` naming convention (`detect_strict`, `extension_to_mime_type_strict`, `filename_to_mime_type_strict`, …).

## Change

Add `mimetype.parse_strict(input) -> Result(MimeType, ParseError)`. It rejects the three malformed shapes with a new `Error(MalformedParameter(segment))` variant naming the offending segment, while remaining identical to `parse` otherwise (including the existing `InvalidParameterName` / `InvalidParameterValue` strict checks). The `strict` flag is threaded through the internal parameter loop; `parse` stays lenient and unchanged.

## Tests (regression guard)

- `parse_strict` rejects trailing `;`, bare `;`, consecutive `;;`, missing `=value`, and empty name,
- accepts well-formed (`charset=utf-8`) and no-parameter inputs,
- still surfaces a non-token parameter name,
- and — crucially — lenient `parse` keeps dropping the same malformed segments, so both contracts are pinned and cannot drift.

`just all` passes on both Erlang and JavaScript targets (format-check + typecheck + glinter + dual-target build `--warnings-as-errors` + dual-target test + docs).

Closes #143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `parse_strict()` for stricter RFC 7231 MIME parameter validation, rejecting malformed segments that the lenient `parse()` previously tolerated
  * Added `MalformedParameter` error variant to clearly identify offending parameter segments
  * Existing `parse()` function behavior unchanged

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/mimetype/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->